### PR TITLE
fix(reward_function): wrap ocamlc subprocess in try/finally to prevent temp file leak

### DIFF
--- a/examples/qwen3-32b-fft-verl-multinode/training/reward_function.py
+++ b/examples/qwen3-32b-fft-verl-multinode/training/reward_function.py
@@ -21,16 +21,17 @@ def check_ocaml_compilation(ocaml_code):
    with tempfile.NamedTemporaryFile(mode='w', suffix='.ml', delete=False) as f:
        f.write(ocaml_code)
        temp_path = f.name
-    
-   result = subprocess.run(['ocamlc', '-c', temp_path], capture_output=True)
-   
-   # Clean up
-   os.unlink(temp_path)
-   for ext in ['.cmo', '.cmi']:
-       compiled = temp_path.replace('.ml', ext)
-       if os.path.exists(compiled):
-           os.unlink(compiled)
-   
+
+   try:
+       result = subprocess.run(['ocamlc', '-c', temp_path], capture_output=True)
+   finally:
+       # Clean up source and any compiled artifacts unconditionally
+       os.unlink(temp_path)
+       for ext in ['.cmo', '.cmi']:
+           compiled = temp_path.replace('.ml', ext)
+           if os.path.exists(compiled):
+               os.unlink(compiled)
+
    return result.returncode == 0
 
 def extract_solution(solution_str):

--- a/examples/qwen3-8b-fft-verl/training/reward_function.py
+++ b/examples/qwen3-8b-fft-verl/training/reward_function.py
@@ -21,16 +21,17 @@ def check_ocaml_compilation(ocaml_code):
    with tempfile.NamedTemporaryFile(mode='w', suffix='.ml', delete=False) as f:
        f.write(ocaml_code)
        temp_path = f.name
-    
-   result = subprocess.run(['ocamlc', '-c', temp_path], capture_output=True)
-   
-   # Clean up
-   os.unlink(temp_path)
-   for ext in ['.cmo', '.cmi']:
-       compiled = temp_path.replace('.ml', ext)
-       if os.path.exists(compiled):
-           os.unlink(compiled)
-   
+
+   try:
+       result = subprocess.run(['ocamlc', '-c', temp_path], capture_output=True)
+   finally:
+       # Clean up source and any compiled artifacts unconditionally
+       os.unlink(temp_path)
+       for ext in ['.cmo', '.cmi']:
+           compiled = temp_path.replace('.ml', ext)
+           if os.path.exists(compiled):
+               os.unlink(compiled)
+
    return result.returncode == 0
 
 def extract_solution(solution_str):

--- a/examples/qwen3-8b-lora-verl/training/reward_function.py
+++ b/examples/qwen3-8b-lora-verl/training/reward_function.py
@@ -21,16 +21,17 @@ def check_ocaml_compilation(ocaml_code):
    with tempfile.NamedTemporaryFile(mode='w', suffix='.ml', delete=False) as f:
        f.write(ocaml_code)
        temp_path = f.name
-    
-   result = subprocess.run(['ocamlc', '-c', temp_path], capture_output=True)
-   
-   # Clean up
-   os.unlink(temp_path)
-   for ext in ['.cmo', '.cmi']:
-       compiled = temp_path.replace('.ml', ext)
-       if os.path.exists(compiled):
-           os.unlink(compiled)
-   
+
+   try:
+       result = subprocess.run(['ocamlc', '-c', temp_path], capture_output=True)
+   finally:
+       # Clean up source and any compiled artifacts unconditionally
+       os.unlink(temp_path)
+       for ext in ['.cmo', '.cmi']:
+           compiled = temp_path.replace('.ml', ext)
+           if os.path.exists(compiled):
+               os.unlink(compiled)
+
    return result.returncode == 0
 
 def extract_solution(solution_str):


### PR DESCRIPTION
## What

`check_ocaml_compilation` creates a named temp file (`delete=False`) and
relies on explicit `os.unlink` calls for cleanup. If `ocamlc` is not on
`$PATH`, `subprocess.run` raises `FileNotFoundError` before the cleanup
block is reached, leaking the `.ml` source file on disk.

## Why it matters

`compute_score` is called by the VERL reward model on every rollout sample
during GRPO training. Over a full run this can produce thousands of leaked
files in `/tmp`, eventually exhausting inodes or disk space and crashing
training in a way that is hard to diagnose.

## Fix

Wrap the `subprocess.run` call in `try/finally` so cleanup runs
unconditionally — whether compilation succeeds, fails, or raises.

## Files changed

- `examples/qwen3-8b-fft-verl/training/reward_function.py`
- `examples/qwen3-32b-fft-verl-multinode/training/reward_function.py`
- `examples/qwen3-8b-lora-verl/training/reward_function.py`

All three files were identical, so the fix is identical across all three.

## Testing

Verified locally by mocking a missing `ocamlc` binary — temp file is now
cleaned up even when `FileNotFoundError` is raised.