### PR TITLE
Add Isaac Lab RL training recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
   <a href="https://www.baseten.co/">
     <img alt="Baseten" src="https://github.com/user-attachments/assets/1e342a9e-56a5-4919-b776-228a5fc1288e">
   </a>
-  
+
 <p align="center">
   <strong><a href="https://docs.baseten.co/examples/deploy-your-first-model">Inference docs</a> | <a href="https://docs.baseten.co/training/overview">Training docs</a></strong>
 </p>
@@ -41,9 +41,9 @@ Before getting started, ensure you have the following:
   - This is required to access models on Huggingface that have gated access. More information on setting up Huggingface access tokens can be found [here](https://huggingface.co/docs/hub/en/security-tokens).
 - Python 3.8 to 3.11 installed. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html) env recommended.
 
-### Run the examples 
+### Run the examples
 
-#### Install `truss` 
+#### Install `truss`
 Use the appropriate command for your package manager
 ```bash
 # pip
@@ -94,6 +94,12 @@ Loops is Baseten's SDK for online training: write your training loop in plain Py
 The Programmatic Training API lets you launch and manage machine learning training jobs directly from your Python code, rather than relying solely on CLI commands or configuration files.
 
 [`recipes/programmatic-training-api/README.md`](recipes/programmatic-training-api/README.md)
+
+### Isaac Lab RL
+
+[NVIDIA Isaac Lab](https://github.com/isaac-sim/IsaacLab) is a GPU-accelerated robot-learning framework built on Isaac Sim. This recipe runs headless reinforcement-learning training (Cartpole by default, any Isaac Lab task) as a Baseten training job. Note Isaac Sim's RTX renderer requires an RT-core GPU (A10G/L4/T4) — it does not run on H100/A100/B200.
+
+[`recipes/isaac-lab/README.md`](recipes/isaac-lab/README.md)
 
 ### Long-context SFT
 

--- a/recipes/isaac-lab/README.md
+++ b/recipes/isaac-lab/README.md
@@ -1,0 +1,77 @@
+# Isaac Lab RL on Baseten
+
+[NVIDIA Isaac Lab](https://github.com/isaac-sim/IsaacLab) is a GPU-accelerated robot-learning
+framework built on Isaac Sim. This recipe runs headless reinforcement-learning training as a
+Baseten training job — installing Isaac Sim + Isaac Lab into a standard PyTorch image and
+training a policy with [`rsl_rl`](https://github.com/leggedrobotics/rsl_rl).
+
+The default configuration trains the `Isaac-Cartpole-v0` task on a single A10G. The same
+recipe runs any Isaac Lab task (e.g. `Isaac-Velocity-Rough-Anymal-C-v0` for legged locomotion)
+— set `TASK` and `MAX_ITERATIONS` in `run.sh`.
+
+## Hardware requirement: use an RT-core GPU
+
+> **Isaac Lab does not run on H100, A100, or B200.** These are compute-only SKUs without RT
+> cores, and their datacenter driver cannot create a Vulkan device. Isaac Sim's RTX renderer
+> initializes Vulkan even in `--headless` mode and requires hardware ray tracing, so it fails
+> at GPU-foundation init on those GPUs (`vkCreateInstance failed: ERROR_INCOMPATIBLE_DRIVER`).
+
+Use a GPU with RT cores: **A10G** (default), **L4**, or **T4** (NVIDIA's documented minimum).
+For most Isaac Lab RL workloads the simulator is the bottleneck rather than raw FLOPs, so these
+are well-matched. (If you need H100-class compute, you would have to decouple simulation from
+learning across machines — Isaac Lab couples them on one GPU by design.)
+
+## How it works
+
+`config.py` defines the training job. Two environment variables are essential:
+
+- **`NVIDIA_DRIVER_CAPABILITIES=all`** — the container default (`compute,utility`) injects only
+  CUDA libraries. Setting `all` makes the NVIDIA container runtime also inject the graphics /
+  Vulkan stack (`libGLX_nvidia`, `nvidia_icd.json`, `libnvidia-rtcore`) that the renderer needs.
+- **`OMNI_KIT_ACCEPT_EULA=YES`** — accepts the Omniverse EULA non-interactively; otherwise
+  `import isaacsim` blocks on a prompt and the job hangs.
+
+`run.sh` then installs the userspace GL/Vulkan libraries, `isaacsim[all,extscache]==5.1.0`,
+clones Isaac Lab, installs `rsl_rl`, and launches headless training.
+
+## Prerequisites
+
+1. A [Baseten account](https://baseten.co/signup) with access to an RT-core GPU (A10G/L4/T4).
+2. The Truss CLI installed and configured (`pip install -U truss && truss login`).
+
+If you need GPU access or a higher quota, [reach out to us](mailto:support@baseten.co).
+
+## Getting started
+
+```bash
+git clone https://github.com/basetenlabs/ml-cookbook.git
+cd ml-cookbook/recipes/isaac-lab
+truss train push config.py
+```
+
+Monitor the job:
+
+```bash
+truss train logs --job-id <JOB_ID> --tail
+```
+
+## What it trains
+
+The default run trains a Cartpole balancing policy for 150 `rsl_rl` iterations. Outputs
+(checkpoints + TensorBoard logs) are written under `/tmp/checkpoints` and synced as Baseten
+training checkpoints. To train a different task or longer, edit the variables at the top of
+`run.sh`:
+
+```bash
+TASK="Isaac-Velocity-Rough-Anymal-C-v0"   # any Isaac Lab task id
+MAX_ITERATIONS=1500
+```
+
+## Notes
+
+- **First run is slow.** Isaac Sim downloads Kit extensions and compiles RTX shaders on first
+  launch (several minutes before training starts). The shader cache lives under `~/.cache`,
+  which is on the persistent cache mount, so subsequent runs are much faster.
+- The base image (`pytorch/pytorch:2.7.0-cuda12.8-cudnn9-devel`) is chosen because its
+  Ubuntu 22.04 / Python 3.11 / torch 2.7.0+cu128 stack matches Isaac Sim 5.1 exactly — no
+  Python or torch reinstall required.

--- a/recipes/isaac-lab/config.py
+++ b/recipes/isaac-lab/config.py
@@ -1,16 +1,13 @@
 from truss_train import definitions
 from truss.base import truss_config
 
-project_name = "isaac-lab-cartpole"
+project_name = "Isaac Lab Cartpole RL - ML Cookbook"
 
-# Ubuntu 22.04 / GLIBC 2.35 / Python 3.11 / torch 2.7.0+cu128 — an exact match for
-# Isaac Sim 5.1's requirements, so no Python or torch reinstall is needed.
+# Matches Isaac Sim 5.1 exactly (Ubuntu 22.04, Python 3.11, torch 2.7.0+cu128).
 BASE_IMAGE = "pytorch/pytorch:2.7.0-cuda12.8-cudnn9-devel"
 
-# Isaac Sim's RTX renderer initializes Vulkan even in --headless mode and requires
-# hardware ray tracing. This only works on RT-core GPUs (T4, A10G, L4). Compute SKUs
-# (A100, H100, B200) have no RT cores and cannot create a Vulkan device — Isaac Sim
-# fails at GPU-foundation init on those. A10G is a good default for Isaac Lab RL.
+# Isaac Sim's RTX renderer needs hardware ray tracing, so it only runs on RT-core GPUs
+# (T4, A10G, L4) — not on compute SKUs (A100, H100, B200), which can't create a Vulkan device.
 ACCELERATOR = truss_config.Accelerator.A10G
 GPU_COUNT = 1
 
@@ -20,13 +17,10 @@ training_runtime = definitions.Runtime(
         "./run.sh",
     ],
     environment_variables={
-        # Default is "compute,utility", which injects only CUDA libs. "all" makes the
-        # NVIDIA container runtime also inject the graphics/Vulkan stack (libGLX_nvidia,
-        # nvidia_icd.json, libnvidia-rtcore) that the RTX renderer needs.
+        # "all" makes the container runtime inject the graphics/Vulkan stack, not just CUDA.
         "NVIDIA_DRIVER_CAPABILITIES": "all",
         # Accept the Omniverse EULA non-interactively; otherwise `import isaacsim` blocks.
         "OMNI_KIT_ACCEPT_EULA": "YES",
-        # Route pip + Kit shader caches onto the persistent cache mount for fast reruns.
         "PIP_CACHE_DIR": "/root/.cache/pip",
     },
     cache_config=definitions.CacheConfig(

--- a/recipes/isaac-lab/config.py
+++ b/recipes/isaac-lab/config.py
@@ -1,0 +1,58 @@
+from truss_train import definitions
+from truss.base import truss_config
+
+project_name = "isaac-lab-cartpole"
+
+# Ubuntu 22.04 / GLIBC 2.35 / Python 3.11 / torch 2.7.0+cu128 — an exact match for
+# Isaac Sim 5.1's requirements, so no Python or torch reinstall is needed.
+BASE_IMAGE = "pytorch/pytorch:2.7.0-cuda12.8-cudnn9-devel"
+
+# Isaac Sim's RTX renderer initializes Vulkan even in --headless mode and requires
+# hardware ray tracing. This only works on RT-core GPUs (T4, A10G, L4). Compute SKUs
+# (A100, H100, B200) have no RT cores and cannot create a Vulkan device — Isaac Sim
+# fails at GPU-foundation init on those. A10G is a good default for Isaac Lab RL.
+ACCELERATOR = truss_config.Accelerator.A10G
+GPU_COUNT = 1
+
+training_runtime = definitions.Runtime(
+    start_commands=[
+        "chmod +x ./run.sh",
+        "./run.sh",
+    ],
+    environment_variables={
+        # Default is "compute,utility", which injects only CUDA libs. "all" makes the
+        # NVIDIA container runtime also inject the graphics/Vulkan stack (libGLX_nvidia,
+        # nvidia_icd.json, libnvidia-rtcore) that the RTX renderer needs.
+        "NVIDIA_DRIVER_CAPABILITIES": "all",
+        # Accept the Omniverse EULA non-interactively; otherwise `import isaacsim` blocks.
+        "OMNI_KIT_ACCEPT_EULA": "YES",
+        # Route pip + Kit shader caches onto the persistent cache mount for fast reruns.
+        "PIP_CACHE_DIR": "/root/.cache/pip",
+    },
+    cache_config=definitions.CacheConfig(
+        enabled=True,
+    ),
+    checkpointing_config=definitions.CheckpointingConfig(
+        enabled=True,
+        checkpoint_path="/tmp/checkpoints",
+    ),
+)
+
+training_compute = definitions.Compute(
+    accelerator=truss_config.AcceleratorSpec(
+        accelerator=ACCELERATOR,
+        count=GPU_COUNT,
+    ),
+    node_count=1,
+)
+
+training_job = definitions.TrainingJob(
+    image=definitions.Image(base_image=BASE_IMAGE),
+    compute=training_compute,
+    runtime=training_runtime,
+)
+
+_ = definitions.TrainingProject(
+    name=project_name,
+    job=training_job,
+)

--- a/recipes/isaac-lab/run.sh
+++ b/recipes/isaac-lab/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -eux
+
+# Task and training length are overridable from the environment.
+TASK="${TASK:-Isaac-Cartpole-v0}"
+MAX_ITERATIONS="${MAX_ITERATIONS:-150}"
+ISAACLAB_DIR="${ISAACLAB_DIR:-/root/IsaacLab}"
+
+# System libraries Isaac Sim's renderer needs. The CUDA/Vulkan driver itself is
+# injected by the container runtime (via NVIDIA_DRIVER_CAPABILITIES=all); these are
+# the userspace GL/X11/Vulkan loader libs that the base image does not ship.
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends \
+  libgl1 libglu1-mesa libegl1 libxt6 libxrandr2 libxinerama1 libxcursor1 \
+  libxi6 libsm6 libxext6 libxrender1 libglib2.0-0 libvulkan1 vulkan-tools git
+
+# Isaac Sim 5.1 (matches the base image's Python 3.11 + torch 2.7.0+cu128).
+pip install "isaacsim[all,extscache]==5.1.0" --extra-index-url https://pypi.nvidia.com
+
+# Isaac Lab + the rsl_rl reinforcement learning framework.
+if [ ! -d "${ISAACLAB_DIR}" ]; then
+  git clone https://github.com/isaac-sim/IsaacLab.git --branch main --depth 1 "${ISAACLAB_DIR}"
+fi
+cd "${ISAACLAB_DIR}"
+./isaaclab.sh --install rsl_rl
+
+# Persist run outputs (rsl_rl writes to ./logs/rsl_rl/<task>/<timestamp>/) by pointing
+# the logs directory at the Baseten checkpoint path, so policies + TensorBoard logs sync.
+mkdir -p /tmp/checkpoints
+rm -rf "${ISAACLAB_DIR}/logs"
+ln -s /tmp/checkpoints "${ISAACLAB_DIR}/logs"
+
+# Headless RL training. The first run compiles RTX shaders (several minutes); the
+# shader cache lives under ~/.cache, which is on the persistent cache mount.
+./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+  --task="${TASK}" \
+  --headless \
+  --max_iterations "${MAX_ITERATIONS}"


### PR DESCRIPTION
## What

Adds a new `recipes/isaac-lab/` recipe that runs headless reinforcement-learning training on Baseten using [NVIDIA Isaac Lab](https://github.com/isaac-sim/IsaacLab) (Isaac Sim 5.1 + `rsl_rl`). Defaults to `Isaac-Cartpole-v0` on a single A10G; any Isaac Lab task works by setting `TASK`/`MAX_ITERATIONS` in `run.sh`.

Files:
- `config.py` — training job (A10G, `NVIDIA_DRIVER_CAPABILITIES=all`, `OMNI_KIT_ACCEPT_EULA=YES`, cache + checkpointing).
- `run.sh` — installs GL/Vulkan libs + `isaacsim[all,extscache]==5.1.0`, clones Isaac Lab, installs `rsl_rl`, runs headless training.
- `README.md` — recipe docs, plus a top-level README index entry.

## Why the hardware note matters

The recipe documents (and `config.py` enforces by default) that **Isaac Sim does not run on H100/A100/B200**. Those are compute-only SKUs without RT cores, and their datacenter driver can't create a Vulkan device — Isaac Sim's RTX renderer initializes Vulkan even in `--headless` and fails at GPU-foundation init (`vkCreateInstance failed: ERROR_INCOMPATIBLE_DRIVER`). RT-core GPUs (A10G/L4/T4) are required.

## Testing

Validated end-to-end over an SSH training job:
- **A10G**: Vulkan initializes (`NVIDIA A10G, driver 580.159.03, Vulkan 1.4.312`), Isaac Sim renderer starts (`Simulation App Startup Complete`), and Cartpole `rsl_rl` training ran to completion (`rc=0`).
- **H100**: confirmed the failure mode three ways (native NVIDIA Vulkan ICD returns no `vkCreateInstance`; software lavapipe rejected for lacking ray tracing), backing the hardware note.

The base image (`pytorch/pytorch:2.7.0-cuda12.8-cudnn9-devel`) was chosen because its Ubuntu 22.04 / Python 3.11 / torch 2.7.0+cu128 stack matches Isaac Sim 5.1 exactly.