### PR TITLE
Docs: align GR00T recipe with verified H100 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ truss train get_checkpoint_urls --job-id $JOB_ID
 
 ### Fine-tune NVIDIA Isaac-GR00T N1
 
-[NVIDIA Isaac-GR00T](https://github.com/NVIDIA/Isaac-GR00T) is a ~3B Vision-Language-Action foundation model for humanoid robots. This recipe fine-tunes it on a LeRobot-format dataset. Training is pure PyTorch on pre-recorded demonstrations — no simulator or rendering stack — so it runs on any GPU. It defaults to a single A10G (24GB) via `--no-tune_diffusion_model`; use a 40GB+ GPU (L40S/H100) for a full fine-tune.
+[NVIDIA Isaac-GR00T](https://github.com/NVIDIA/Isaac-GR00T) is a ~3B Vision-Language-Action foundation model for humanoid robots. This recipe fine-tunes it on a LeRobot-format dataset. Training is pure PyTorch on pre-recorded demonstrations — no simulator or rendering stack. It defaults to a full fine-tune on a single H100; to run on a 24GB GPU (A10G), use LoRA (`--lora-rank 64`).
 
 [`recipes/isaac-groot/README.md`](recipes/isaac-groot/README.md)
 

--- a/recipes/isaac-groot/README.md
+++ b/recipes/isaac-groot/README.md
@@ -40,7 +40,11 @@ base model needs no token.
 
 ## Notes
 
+- **Verified on H100.** Run end-to-end on a single H100 — full fine-tune, 100
+  steps, full 3B checkpoint synced, job completed cleanly.
 - **Pinned to n1.5.** `run.sh` clones the `n1.5-release` tag, whose
-  `scripts/gr00t_finetune.py` entrypoint and `--no-tune-diffusion-model` flag are
-  stable. (`main` has moved to N1.7, which uses
-  `gr00t/experiment/launch_finetune.py` instead.)
+  `scripts/gr00t_finetune.py` entrypoint and CLI flags are stable. (`main` has
+  moved to N1.7, which uses `gr00t/experiment/launch_finetune.py` instead.)
+- **Weights & Biases is off.** `run.sh` sets `WANDB_MODE=disabled` (the job has no
+  W&B key); metrics print to the job logs. To enable it, set `WANDB_MODE=online`
+  and add a `WANDB_API_KEY` workspace secret.


### PR DESCRIPTION
Follow-up to #112 (the merged GR00T recipe), bringing the docs in line with the **verified H100** configuration.

- **Root `README.md`** — the GR00T summary still described the old A10G / `--no-tune_diffusion_model` default. Updated to: full fine-tune on a single H100, with LoRA (`--lora-rank 64`) as the A10G path.
- **`recipes/isaac-groot/README.md`** — added a *Verified on H100* note (full fine-tune, 100 steps, 3B checkpoint synced, job completed) and a Weights & Biases note (`WANDB_MODE=disabled` by default; how to enable). Dropped a stale `--no-tune-diffusion-model` mention since the recipe now runs a full fine-tune.

Verified twice on Baseten Training (H100, `TRAINING_JOB_COMPLETED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
