### PR TITLE
Add GLM-5.1 ms-swift LoRA fine-tuning recipe

### DIFF
--- a/examples/glm-5.1-msswift/training/README.md
+++ b/examples/glm-5.1-msswift/training/README.md
@@ -1,0 +1,34 @@
+# GLM-5.1 Fine-Tuning with MS-Swift
+
+This example fine-tunes the GLM-5.1 model using the MS-Swift framework with MegatronLM on Baseten.
+
+**Resources:** 4 nodes, 8x H200 GPUs each (32 GPUs total)
+
+## Prerequisites
+
+1. [Create a Baseten account](https://baseten.co/signup) if you don't already have one.
+2. Install the Truss CLI:
+   ```bash
+   # pip
+   pip install -U truss
+   # or uv
+   uv add truss
+   ```
+
+## Getting Started
+
+Initialize the example, navigate into the directory, and push the training job:
+
+```bash
+truss train init --examples glm-5.1-msswift
+cd glm-5.1-msswift
+truss train push config.py
+```
+
+> **Note:** This example requires H200 GPUs. You may need to [contact Baseten](https://www.baseten.co/contact) to get approval for this instance type before running the job.
+
+## Notes
+
+- GLM-5.1 is a 744B MoE model (256 routed experts) using DeepSeek Sparse Attention (DSA). It needs a `megatron-core >= 0.17.1` image — the tag pinned in `config.py` works as-is.
+- The 256 experts shard cleanly only across power-of-2 GPU counts, so this recipe uses 4 nodes (`expert_model_parallel_size=32`). 24 GPUs (3 nodes) cannot fit the weights.
+- `max_length` is set to **16384**. Longer sequences are currently limited by the DSA indexer, which materializes an O(seqlen²) score matrix; context-parallel support for DSA (the fix for long context) is not yet available upstream.

--- a/examples/glm-5.1-msswift/training/config.py
+++ b/examples/glm-5.1-msswift/training/config.py
@@ -1,0 +1,47 @@
+# Import necessary classes from the Baseten Training SDK
+from truss_train import definitions
+from truss.base import truss_config
+
+project_name = "LoRA GLM-5.1 - ML Cookbook"
+
+# 1. Define a base image for your training job
+# GLM-5.1 (glm_moe_dsa) requires megatron-core >= 0.17.1: earlier builds lack the
+# DSA indexer kernel and reject the model's interleaved-RoPE + multi-latent-attention combo.
+BASE_IMAGE = "baseten/megatron:py3.12.13-cuda12.8.1-torch2.9.1-fa2.8.3-megatron0.17.1-msswift4.3.1-peftstamp"
+
+# 2. Define the Runtime Environment for the Training Job
+training_runtime = definitions.Runtime(
+    start_commands=[
+        "chmod +x ./run.sh && ./run.sh"
+    ],
+    checkpointing_config=definitions.CheckpointingConfig(
+        enabled=True,
+    ),
+    cache_config=definitions.CacheConfig(
+        enabled=True,
+    ),
+)
+
+# 3. Define the Compute Resources for the Training Job
+# 256 routed experts shard cleanly only across power-of-2 GPU counts; 4x8 gives EP=32.
+training_compute = definitions.Compute(
+    node_count=4,
+    accelerator=truss_config.AcceleratorSpec(
+        accelerator=truss_config.Accelerator.H200,
+        count=8,
+    ),
+)
+
+# 4. Define the Training Job
+my_training_job = definitions.TrainingJob(
+    image=definitions.Image(base_image=BASE_IMAGE),
+    compute=training_compute,
+    runtime=training_runtime,
+)
+
+
+# This config will be pushed using the Truss CLI.
+# The association of the job to the project happens at the time of push.
+first_project_with_job = definitions.TrainingProject(
+    name=project_name, job=my_training_job
+)

--- a/examples/glm-5.1-msswift/training/run.sh
+++ b/examples/glm-5.1-msswift/training/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+export HF_HOME=$BT_RW_CACHE_DIR/huggingface
+
+SAVE_FULL_MODEL=false
+checkpoint_dir="$BT_CHECKPOINT_DIR/glm-5.1-lora-64-128"
+
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NPROC_PER_NODE=$BT_NUM_GPUS NNODES=$BT_GROUP_SIZE NODE_RANK=$BT_NODE_RANK MASTER_ADDR=$BT_LEADER_ADDR megatron sft \
+    --model zai-org/GLM-5.1 \
+    --template glm5_1 \
+    --output_dir $checkpoint_dir \
+    --dataset 'winglian/pirate-ultrachat-10k' \
+    --save_safetensors true \
+    --tuner_type lora \
+    --lora_rank 64 \
+    --lora_alpha 128 \
+    --target_modules all-linear \
+    --split_dataset_ratio 0.01 \
+    --tensor_model_parallel_size 8 \
+    --expert_model_parallel_size 32 \
+    --moe_permute_fusion true \
+    --moe_grouped_gemm true \
+    --moe_shared_expert_overlap true \
+    --moe_aux_loss_coeff 1e-3 \
+    --micro_batch_size 1 \
+    --global_batch_size 4 \
+    --packing true \
+    --recompute_granularity full \
+    --recompute_method uniform \
+    --recompute_num_layers 4 \
+    --train_iters 100 \
+    --eval_iters 0 \
+    --finetune true \
+    --cross_entropy_loss_fusion true \
+    --lr 1e-4 \
+    --lr_warmup_fraction 0.05 \
+    --min_lr 1e-5 \
+    --save_steps 100 \
+    --max_length 16384 \
+    --dataloader_num_workers 8 \
+    --dataset_num_proc 8 \
+    --no_save_optim true \
+    --no_save_rng true \
+    --sequence_parallel true \
+    --attention_backend flash \
+    --optimizer_cpu_offload true \
+    --use_precision_aware_optimizer true \
+    --merge_lora $SAVE_FULL_MODEL \
+    --use_hf 1


### PR DESCRIPTION
Adds `examples/glm-5.1-msswift` — LoRA SFT of **GLM-5.1** (744B `glm_moe_dsa` MoE, 256 routed experts, DeepSeek Sparse Attention) via MS-Swift + Megatron, mirroring the existing `glm-4.7-msswift` recipe.

### Key differences from the GLM-4.7 recipe
- **Image:** requires `megatron-core >= 0.17.1` (`...megatron0.17.1-msswift4.3.1-peftstamp`). Earlier builds lack the DSA indexer kernel and hard-reject GLM-5.1's interleaved-RoPE + multi-latent-attention combo.
- **Compute:** 4 nodes × 8 H200 (`expert_model_parallel_size=32`). The 256 experts shard cleanly only across power-of-2 GPU counts; 24 GPUs can't fit the weights.
- **Args:** `--template glm5_1`, `--tuner_type lora`, `--output_dir`, `--dataloader_num_workers` (the 4.x ms-swift arg surface).
- **`max_length=16384`:** longer context currently OOMs in the DSA indexer's O(seqlen²) score matrix; context-parallel support for DSA isn't available upstream yet.

### Validation
Ran end-to-end on 4×8 H200 at 16k seqlen — completed training and saved a LoRA checkpoint.