### PR TITLE
feat(examples): add Kimi-K2.6 LoRA merge recipe

### DIFF
--- a/examples/kimi-k2.6-lora-merge/training/README.md
+++ b/examples/kimi-k2.6-lora-merge/training/README.md
@@ -1,0 +1,58 @@
+# Kimi-K2.6 LoRA Merge
+
+Merges a Loops LoRA adapter into the quantized Kimi-K2.6 base, producing a
+single deployable checkpoint that serves on **stock vLLM with no patches**.
+
+The Loops sampler adapter targets attention projections + `lm_head`, which the
+Kimi-K2.6 INT4 release stores as **BF16** (only the MoE experts are packed
+INT4). So the merge happens **in place on CPU** — no dequantize/requantize — and
+the experts and `quantization_config` are carried through untouched.
+
+**Resources:** 1x H100 GPU. The GPU is idle; H100 is used only for its large
+node-local disk to hold the ~555 GB base mirror. The merge runs on CPU and
+peaks at ~50 GB RAM.
+
+## What it does
+
+1. `load_checkpoint_config` pulls the Loops **sampler** adapter via the
+   user-facing checkpoint loader (`LoopsCheckpoint.from_checkpoint(...)`, which
+   resolves to `bt://loops:...` server-side — no raw S3 URL).
+2. `WeightsSource` mirrors the quantized `moonshotai/Kimi-K2.6` base to
+   `/app/base`.
+3. `merge.py` rewrites only the shards holding the adapted BF16 tensors
+   (`W += (alpha/r)·BᵀA`) and copies everything else through.
+4. The merged checkpoint is written to `$BT_CHECKPOINT_DIR/merged`.
+
+## Prerequisites
+
+1. A Baseten account and the Truss CLI (`pip install -U truss`).
+2. An `hf_access_token` secret in your org for the base download.
+3. Set `LOOPS_RUN_ID` / `LOOPS_CHECKPOINT_NAME` in `config.py` to your Loops run
+   and its `sampler` checkpoint name.
+
+## Getting started
+
+```bash
+truss train init --examples kimi-k2.6-lora-merge
+cd kimi-k2.6-lora-merge
+truss train push config.py
+```
+
+Monitor:
+
+```bash
+truss train logs --job-id <JOB_ID> --tail
+```
+
+When the job finishes, the merged checkpoint is at `$BT_CHECKPOINT_DIR/merged` —
+a complete HF checkpoint (shards, `config.json` with the original
+`quantization_config`, tokenizer) ready to deploy.
+
+## Notes
+
+- `merge.py` validates that every adapter target lands on a BF16 `.weight` and
+  **fails loudly** if any target is a packed (quantized) tensor — that would
+  mean the adapter touched the MoE experts and requires the slower
+  dequantize → merge → requantize path instead.
+- The merge is I/O-bound (reading/writing ~555 GB), not compute-bound; tune
+  `--workers` in `run.sh` to your instance's CPU/RAM.

--- a/examples/kimi-k2.6-lora-merge/training/config.py
+++ b/examples/kimi-k2.6-lora-merge/training/config.py
@@ -1,0 +1,67 @@
+from truss_train import (
+    CheckpointingConfig,
+    Compute,
+    Image,
+    LoadCheckpointConfig,
+    LoopsCheckpoint,
+    Runtime,
+    TrainingJob,
+    TrainingProject,
+    WeightsSource,
+)
+from truss.base.truss_config import AcceleratorSpec
+
+BASE_IMAGE = "pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime"
+
+# The Loops run + checkpoint to merge. target="sampler" selects the exported
+# inference adapter (the deployable LoRA), not the full trainer state. Fill these
+# in with your own run — find them via `truss train checkpoints list`.
+LOOPS_RUN_ID = "<your-loops-run-id>"
+LOOPS_CHECKPOINT_NAME = "<your-sampler-checkpoint-name>"
+
+training_runtime = Runtime(
+    start_commands=["chmod +x ./run.sh && ./run.sh"],
+    # The merged checkpoint is written to $BT_CHECKPOINT_DIR; the Kimi-K2.6
+    # base is ~555 GB, so size the volume accordingly.
+    checkpointing_config=CheckpointingConfig(enabled=True, volume_size_gib=700),
+    # Pull the Loops sampler adapter via the user-facing checkpoint loader
+    # (resolves to bt://loops:... server-side — no raw S3 URL needed). It lands
+    # under /tmp/loaded_checkpoints/.
+    load_checkpoint_config=LoadCheckpointConfig(
+        enabled=True,
+        checkpoints=[
+            LoopsCheckpoint.from_checkpoint(
+                run_id=LOOPS_RUN_ID,
+                checkpoint_name=LOOPS_CHECKPOINT_NAME,
+                target="sampler",
+            ),
+        ],
+    ),
+)
+
+# H100 is used for its large node-local disk (the 555 GB base mirror), not the
+# GPU — the merge runs on CPU. The merge peaks at ~50 GB RAM / a few cores.
+training_compute = Compute(
+    accelerator=AcceleratorSpec(accelerator="H100", count=1),
+    cpu_count=16,
+    memory="96Gi",
+)
+
+training_job = TrainingJob(
+    image=Image(base_image=BASE_IMAGE),
+    compute=training_compute,
+    runtime=training_runtime,
+    # The quantized Kimi-K2.6 base, mirrored to /app/base.
+    weights=[
+        WeightsSource(
+            source="hf://moonshotai/Kimi-K2.6",
+            mount_location="/app/base",
+            auth_secret_name="hf_access_token",
+        ),
+    ],
+)
+
+training_project = TrainingProject(
+    name="kimi-k2.6-lora-merge",
+    job=training_job,
+)

--- a/examples/kimi-k2.6-lora-merge/training/merge.py
+++ b/examples/kimi-k2.6-lora-merge/training/merge.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Merge a Loops LoRA adapter into a quantized Kimi-K2.6 base, on CPU.
+
+The Kimi-K2.6 INT4 release stores attention + lm_head as BF16 and only the MoE
+experts as packed INT4. Loops adapters target attention + lm_head, so every
+target lands on a BF16 tensor and we can merge in place without dequantizing —
+the experts (and the base's quantization_config) stay untouched, so the output
+is a drop-in checkpoint that serves on stock vLLM with no patches.
+
+Output is a full HF checkpoint: rewritten shards for the touched tensors, every
+other file (experts, config, tokenizer) copied through unchanged.
+"""
+
+import argparse
+import json
+import os
+import shutil
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+ADAPTER_PREFIX = "base_model.model."
+
+
+def strip_adapter_key(adapter_key: str) -> tuple[str, str]:
+    key = adapter_key.removeprefix(ADAPTER_PREFIX)
+    if key.endswith(".lora_A.weight"):
+        return key[: -len(".lora_A.weight")] + ".weight", "A"
+    if key.endswith(".lora_B.weight"):
+        return key[: -len(".lora_B.weight")] + ".weight", "B"
+    raise ValueError(f"Unrecognized adapter key: {adapter_key}")
+
+
+def load_adapter_pairs(adapter_dir: Path) -> dict[str, dict[str, torch.Tensor]]:
+    pairs: dict[str, dict[str, torch.Tensor]] = {}
+    with safe_open(str(adapter_dir / "adapter_model.safetensors"), framework="pt", device="cpu") as f:
+        for k in f.keys():
+            base_key, side = strip_adapter_key(k)
+            pairs.setdefault(base_key, {})[side] = f.get_tensor(k)
+    incomplete = [k for k, p in pairs.items() if set(p) != {"A", "B"}]
+    if incomplete:
+        raise ValueError(f"Incomplete LoRA pairs: {incomplete[:5]}")
+    return pairs
+
+
+def normalize_to_base(key: str, weight_map: dict[str, str]) -> str:
+    # Tinker adapters may use the text-model namespace; the VL checkpoint nests
+    # those tensors under language_model.*.
+    if key in weight_map:
+        return key
+    for cand in (f"language_model.{key}", key.removeprefix("language_model.")):
+        if cand in weight_map:
+            return cand
+    return key
+
+
+def validate_targets(pairs: dict, weight_map: dict[str, str]) -> None:
+    packed, missing = [], []
+    for key in pairs:
+        if key in weight_map:
+            continue
+        if key[: -len(".weight")] + ".weight_packed" in weight_map:
+            packed.append(key)
+        else:
+            missing.append(key)
+    if packed:
+        raise ValueError(
+            f"{len(packed)} targets are packed (quantized) tensors this fast "
+            f"merger cannot touch: {packed[:5]}"
+        )
+    if missing:
+        raise ValueError(f"{len(missing)} targets missing from base: {missing[:5]}")
+
+
+def stage_then_place(write_to, shard: str, staging_dir: Path, out_dir: Path) -> None:
+    # safetensors writes its atomic-rename temp (.tmp<random>) into the target's
+    # own directory. Point that at staging/ (same filesystem, but no config.json
+    # so it is never reconciled as a checkpoint), then os.rename the finished
+    # file into out_dir — a same-fs atomic move, so the checkpoint dir only ever
+    # receives complete shards and never a transient .tmp for the sync to orphan.
+    staged = staging_dir / shard
+    write_to(str(staged))
+    os.replace(staged, out_dir / shard)
+
+
+def merge_shard(shard: str, base_dir: Path, staging_dir: Path, out_dir: Path, pairs: dict, scale: float) -> int:
+    merged = 0
+    tensors: dict[str, torch.Tensor] = {}
+    with safe_open(str(base_dir / shard), framework="pt", device="cpu") as f:
+        for key in f.keys():
+            w = f.get_tensor(key)
+            pair = pairs.get(key)
+            if pair is not None:
+                a = pair["A"].to(torch.float32)
+                b = pair["B"].to(torch.float32)
+                w = w.to(torch.float32).addmm(b, a, alpha=scale).to(w.dtype)
+                merged += 1
+            tensors[key] = w
+    stage_then_place(lambda dst: save_file(tensors, dst), shard, staging_dir, out_dir)
+    return merged
+
+
+def _worker(args):
+    return args[0], merge_shard(*args)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--adapter-dir", required=True)
+    p.add_argument("--base", required=True)
+    p.add_argument("--output", required=True)
+    p.add_argument("--workers", type=int, default=8)
+    args = p.parse_args()
+
+    base_dir, out_dir = Path(args.base), Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # Sibling of out_dir on the same filesystem. Holds safetensors' transient
+    # .tmp* writes; has no config.json, so it is never picked up as a checkpoint.
+    staging_dir = out_dir.parent / f"_{out_dir.name}_staging"
+    staging_dir.mkdir(parents=True, exist_ok=True)
+
+    cfg = json.loads((Path(args.adapter_dir) / "adapter_config.json").read_text())
+    scale = cfg["lora_alpha"] / cfg["r"]
+    weight_map = json.loads((base_dir / "model.safetensors.index.json").read_text())["weight_map"]
+
+    pairs = {normalize_to_base(k, weight_map): v for k, v in load_adapter_pairs(Path(args.adapter_dir)).items()}
+    validate_targets(pairs, weight_map)
+
+    shards = sorted(set(weight_map.values()))
+    touched = {weight_map[k] for k in pairs}
+    print(f"Preflight OK: {len(pairs)} pairs, scale={scale}, {len(touched)}/{len(shards)} shards touched")
+
+    # Carry every non-shard file (experts config, tokenizer, modeling code,
+    # quantization_config) through verbatim, plus the untouched shards. Skip the
+    # base mount's weight-mirror artifacts: a copied .complete sentinel makes
+    # downstream mirroring of this checkpoint think it is already finished, and
+    # stray .tmp* download files just bloat the output.
+    for item in base_dir.iterdir():
+        if item.name in shards or item.name == ".complete" or item.name.startswith(".tmp"):
+            continue
+        (shutil.copytree if item.is_dir() else shutil.copy2)(item, out_dir / item.name)
+    for shard in shards:
+        if shard not in touched:
+            stage_then_place(lambda dst: shutil.copy2(base_dir / shard, dst), shard, staging_dir, out_dir)
+
+    work = [(s, base_dir, staging_dir, out_dir, {k: pairs[k] for k in pairs if weight_map[k] == s}, scale) for s in sorted(touched)]
+    applied = 0
+    with ProcessPoolExecutor(max_workers=args.workers) as pool:
+        for fut in as_completed(pool.submit(_worker, w) for w in work):
+            shard, n = fut.result()
+            applied += n
+            print(f"  {shard}: {n} merges")
+
+    shutil.rmtree(staging_dir, ignore_errors=True)
+    if applied != len(pairs):
+        raise RuntimeError(f"Applied {applied}/{len(pairs)} LoRA pairs")
+    print(f"DONE: merged {applied} LoRA pairs into {len(shards)} shards at {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/kimi-k2.6-lora-merge/training/run.sh
+++ b/examples/kimi-k2.6-lora-merge/training/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pip install -q safetensors
+
+# load_checkpoint_config downloads the Loops sampler adapter under
+# /tmp/loaded_checkpoints/. Locate the directory holding adapter_config.json.
+ADAPTER_DIR="$(dirname "$(find /tmp/loaded_checkpoints -name adapter_config.json | head -1)")"
+echo "Adapter dir: ${ADAPTER_DIR}"
+
+python merge.py \
+  --adapter-dir "${ADAPTER_DIR}" \
+  --base /app/base \
+  --output "${BT_CHECKPOINT_DIR}/merged" \
+  --workers 8
+
+echo "Merged checkpoint written to ${BT_CHECKPOINT_DIR}/merged"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ description = "ML Cookbook by the Baseten Training Team"
 readme = "README.md"
 requires-python = ">=3.12.2"
 dependencies = [
-    "truss==0.16.0",
+    "truss==0.18.16",
     "requests>=2.28",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,43 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -182,6 +219,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
 ]
 
 [[package]]
@@ -415,6 +496,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -433,6 +556,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -561,7 +701,16 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "requests", specifier = ">=2.28" },
-    { name = "truss", specifier = "==0.16.0" },
+    { name = "truss", specifier = "==0.18.16" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -666,6 +815,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -763,6 +921,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d2/ae/baa80662fa98bfdffa31ad68985ef059d84c6dd5287176bc3bb5fb6df9ae/python_on_whales-0.78.0.tar.gz", hash = "sha256:0deab53cdbdd546f8a220c9205d73194ab187478497377a1d7b91de44140cc08", size = 113911, upload-time = "2025-07-14T17:08:27.789Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/ad/20d6aa4dccd0ba415cd0548da4586a6d0e2f3efedc01d33fad6c8bb9c42b/python_on_whales-0.78.0-py3-none-any.whl", hash = "sha256:c315c35a19f72543cf37f991c006c2056861031407ee199a17777e214eed846d", size = 118087, upload-time = "2025-07-14T17:08:26.737Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -907,6 +1074,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -956,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "truss"
-version = "0.16.0"
+version = "0.18.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -969,6 +1149,7 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "inquirerpy" },
     { name = "jinja2" },
+    { name = "keyring" },
     { name = "libcst" },
     { name = "loguru" },
     { name = "packaging" },
@@ -987,38 +1168,38 @@ dependencies = [
     { name = "truss-transfer" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/d7/2d583faf39cdd4ff14ae631284770a6e0c4761ee1632dc86fdcfb9e4eb3f/truss-0.16.0.tar.gz", hash = "sha256:5665783c197991b67a58bc8550fa706c597fafc894c70fd20c370c79671ae794", size = 510430, upload-time = "2026-04-14T03:14:43.903Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/74/65fdbc07e3a2936dba4e75ffbc3cb679673df54b12150e970cb446a49ccf/truss-0.18.16.tar.gz", hash = "sha256:14b439a08bc6ad431174c2071c040a742b94ea59eb65a2b79e29a3a0d7c1fb84", size = 595329, upload-time = "2026-06-23T15:27:54.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/c2/704e74f6e3e125b74167db24758b0a9a6778c81cf2d2781542d2c0643efe/truss-0.16.0-py3-none-any.whl", hash = "sha256:fc00d2b5a16d7d77e939f0df390687f19b434fafe688f8e52cc436c18ac9f616", size = 622936, upload-time = "2026-04-14T03:14:41.969Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/36fd6af7e68a70ba55fef615d801f6f1775f62dd2fa6bd0e145a9a714b92/truss-0.18.16-py3-none-any.whl", hash = "sha256:cb0aed4b819c9ad6260b4206c20f6c9f02246f0c345e8a63a85e4a3e2c1f9cff", size = 717449, upload-time = "2026-06-23T15:27:51.898Z" },
 ]
 
 [[package]]
 name = "truss-transfer"
-version = "0.0.41"
+version = "0.0.43"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d9/80/34b3ab5e885a62e331d313929a2896dc45a78ef86f32d60be857485d9b53/truss_transfer-0.0.41.tar.gz", hash = "sha256:714677a081e9b0ee8a855296ad42a287eac29af42d9a595178e7ef972f46130a", size = 85577, upload-time = "2026-02-07T02:55:06.954Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/12/882735ae7be115b0d622d530da6eb3b552a0a1b5a9130908f96c3eb12326/truss_transfer-0.0.43.tar.gz", hash = "sha256:502cf3b5639f94dd2dcc7978d38400f870b7c405b97ef59f0e71acb90fb83e90", size = 87180, upload-time = "2026-06-03T21:49:41.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/12/c927d03a264532b30b5068c5b47c7b86f54a4301f1769354512c4cabdb87/truss_transfer-0.0.41-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:fde9b292fbea55570c1133609c61e3a207cafa50b277189b57136e9cbe9ca657", size = 4134652, upload-time = "2026-02-07T02:54:45.375Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/e1/84f680b36ba9435f66d84518ae9cfb51608fec7b31a004c8731abdaac850/truss_transfer-0.0.41-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0d4751679ab049ffff38bd27da05146443c05d52621a2beda40968dbec6275d4", size = 4025254, upload-time = "2026-02-07T02:54:41.358Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/38/ed415d4f89b79acec5a764610be6c6d64137ae542875aeae12acfcfe3c34/truss_transfer-0.0.41-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cac85c01cfa871d1c9e16f9841b631e1b80e001fc51cc93943f95e19b173fdd0", size = 4633332, upload-time = "2026-02-07T02:54:28.868Z" },
-    { url = "https://files.pythonhosted.org/packages/07/19/8a80e8ad676dc2fb0030adbd3da733eef124757c5159a937256023538b79/truss_transfer-0.0.41-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7deb761670ec497b2112a2a719daf1bff0a1ab111fda2d41ba02254dfe2fc838", size = 5382998, upload-time = "2026-02-07T02:54:19.692Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/de/19931e9402915ab3506b87fc2ac51f4e4d96ea7c6d1c092b7136b0dd5897/truss_transfer-0.0.41-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a34a4ab7f6431713784cf2c582106d8eef245d0aae3578255c6c4589371e26a", size = 4479195, upload-time = "2026-02-07T02:54:34.975Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9f/81858966800397a3ffa383d9dd220dbb9fd273f2f3b5a964f6aa25691f3a/truss_transfer-0.0.41-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:8efacc2e28f6dae9f29b4c5ab8a1cc9b25321b75d64e1b59851199a42a03edbc", size = 4632097, upload-time = "2026-02-07T02:54:50.344Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/d7/a391605a7b58b9469b57b71946be87042521a7ac731c193f5d41356c35bd/truss_transfer-0.0.41-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:b5c35ccb5eaf08f2940af9f821cc13d567642dce6915bb7f9e50486e76f59a62", size = 4410857, upload-time = "2026-02-07T02:54:54.206Z" },
-    { url = "https://files.pythonhosted.org/packages/37/5d/4a10434e01c111ef8fafba9ba85d79f050c17f8c309ebef84895ce00abf2/truss_transfer-0.0.41-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:b3afd1e0cbba74e40c89a2b6888b2d232743c59dd8dc5f0ba9684aa264f6785d", size = 4608035, upload-time = "2026-02-07T02:54:58.277Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/9d/6b4ec91dca9fb74e2bb79058f8a4b7e9170321116cd076b7811d56363261/truss_transfer-0.0.41-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:438d29a9b0a8fb60f1937a8aa3177b4feee46ec8e36af73be280eeb195660ecb", size = 4712787, upload-time = "2026-02-07T02:55:02.501Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/27/62c6d18f86bc677ff71a0cc11850dcf35ca6729f4076e6c1e8b3f00219a1/truss_transfer-0.0.41-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a3b66a47b71543b730fed94118afe7fbd3af8e72476ac861a68847f50a9c80fa", size = 4143484, upload-time = "2026-02-07T02:54:47.978Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/f7/96f098b057c9e502f52b4a2a2bfb69a0d64cee46265ebbb037333bbe8683/truss_transfer-0.0.41-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:5d163f15339ebcd72e4faab08aa01563f860ef784ebf1667952e4cddcd21c079", size = 4036897, upload-time = "2026-02-07T02:54:43.139Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/9c/1cf76cee978616c7dca3e4782416cfde0306ddaa1dbc73a6f6008e878864/truss_transfer-0.0.41-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:316fca259a8322c10469b63a97ab7cd20f549a32572cb2b0986911037b9f478b", size = 4646663, upload-time = "2026-02-07T02:54:30.865Z" },
-    { url = "https://files.pythonhosted.org/packages/37/c6/19ea1674ff10d67848bd4daa8b93151da42f733c8a92ed2993e92a2868cd/truss_transfer-0.0.41-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:278a930dd0828e5a3367a092a044bc33726b0084191d5f0e82752f81d186a51e", size = 5384916, upload-time = "2026-02-07T02:54:21.971Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/cf/df5cacdcd6b4c02ba4c28bc6a77b1a8815bdee33f0bfe329f921b4f120e3/truss_transfer-0.0.41-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cac235c2994a66f421fc3dddadec7dcb1c584541913b21fdab2621c54d8fae5e", size = 4487039, upload-time = "2026-02-07T02:54:37.235Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/2f/77784b63a0c9de2a43bff98609d41e2e30f199f6ee8518de644c8e5fec94/truss_transfer-0.0.41-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fc08476bd15b3e7bc5e8760a29168ccaadb4a61df608c6b693c29afa39c984f3", size = 4453888, upload-time = "2026-02-07T02:54:04.242Z" },
-    { url = "https://files.pythonhosted.org/packages/44/0e/2a84c0a7e157310307bd4def983ea03da848b7902f27c533514323b4dc03/truss_transfer-0.0.41-cp38-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:21e15d8ebee52bccb8efcaf5865ee84040fb0099ae854e39d9a2079db3bf1637", size = 4185467, upload-time = "2026-02-07T02:54:11.662Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/ed/3c1911eb7a813fc6c1060f16c01fc5d543cb8a1b2fad304752bf541bff0b/truss_transfer-0.0.41-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fe7fa5e42f3791faaf801d26fa51778866472b51dbe48bd9ce199d9781ba8945", size = 4636241, upload-time = "2026-02-07T02:54:52.348Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/84/95e6b8c48f03c6beb63f80b6e7196eba1f80ab990a6b51ce321ace9848b6/truss_transfer-0.0.41-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:61b4ebec3e25e0ebcad376d456190a8aa0b370cb267c07f3cdc8b302e558a786", size = 4421323, upload-time = "2026-02-07T02:54:56.402Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/84/13a337c6025c9868ff60b9d8dba7018658b56cf3669f4bee42b293166bf9/truss_transfer-0.0.41-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:802f23b8405b267bfb9940d73c21a70def60c7f68a887e194f2f2073118d967c", size = 4619839, upload-time = "2026-02-07T02:55:00.003Z" },
-    { url = "https://files.pythonhosted.org/packages/71/85/f2b3b977f49daa894b8239675bccc966689f5b98532320034f2f9bbc3483/truss_transfer-0.0.41-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ae3d863f8fb8c6167664ca727439d38a8a0b5aa2beccaa231fdbe8c46aab2ed0", size = 4717677, upload-time = "2026-02-07T02:55:04.79Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/16/f7b8d867c4679a6b0c96770fc8c00d7d251d66c36ced4245e9d10ec10001/truss_transfer-0.0.41-cp38-abi3-win_amd64.whl", hash = "sha256:80d69053f84748955b3c00c8ce031a1374c86347f11cd6a606792b93b1ac18ae", size = 3737278, upload-time = "2026-02-07T02:55:08.798Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/44/d0e4fe7d2b61e9714bbb5b20a2a1434ea9fcda3cfc0bc43f7ee199865156/truss_transfer-0.0.43-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:98f2f1ce24784f912f81299aec6b43119620f8acaa0b183ba7b42941800674f4", size = 4116295, upload-time = "2026-06-03T21:49:26.131Z" },
+    { url = "https://files.pythonhosted.org/packages/03/13/9f00eccb1175b74d285954a17fff5f46a975ba78534842af6e4d1d849039/truss_transfer-0.0.43-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:aa9b9ffa9f6abde014a1ae794c14f69c6519bfaac06e767a5d06aa6b68361eee", size = 4009082, upload-time = "2026-06-03T21:49:21.801Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b5/654c24d362c2553c7901369e63e26dc9565fd3806995c095220bfa067605/truss_transfer-0.0.43-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6a56f996f604985d2f685a9610c883dd1cb39c2563d6ae0e5d261e59427cd5d4", size = 4672505, upload-time = "2026-06-03T21:49:15.636Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c1/cec87643f5526d4b5cf3067e4f2d3a4e01f796d9f147bfb1046d8b91dfe3/truss_transfer-0.0.43-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8122c238d6aeb29190365064360224237f1824150b29f128b1444989be9e673f", size = 5367662, upload-time = "2026-06-03T21:49:12.667Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1a/e538f2993103607e0a562d36a90e4cbe6a949ad5af2d2ab279be4152c99e/truss_transfer-0.0.43-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1193eadda2f61b0e0ccd9326faf70a26d9aaed84907c69ef482433784bbdf341", size = 4457337, upload-time = "2026-06-03T21:49:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/82/fbf028bc7e89f18d6a512abe4d51ab69610198c81a01312ecdb614e16857/truss_transfer-0.0.43-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:12413cad72597d9957b2d0e972aec33b46df3fff098e09888ca5aa5a896768d8", size = 4626477, upload-time = "2026-06-03T21:49:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/64/42/b77fcda48068dfa85c115e532447641ed9361537b87e908a458f0e9ee75e/truss_transfer-0.0.43-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:e215e22265e9da7c6a128ee0e76bac7c41bafed4ef524e84cd41b53cbc8554b9", size = 4455083, upload-time = "2026-06-03T21:49:32.691Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2b/a7a4eac36c28e95aca2db85802829ffd75b9cab1ffd0d2601a6ecb6ec530/truss_transfer-0.0.43-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7be6ce558222f13585c4912287a265f791600c9cccac6642f4465096816c2eaa", size = 4648779, upload-time = "2026-06-03T21:49:35.92Z" },
+    { url = "https://files.pythonhosted.org/packages/15/55/ccda666435d602efd8b0f407aa9c1e918c5a650529f347046d345a86d6ba/truss_transfer-0.0.43-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ba54ad6757e0ffd73e7a0e92e75f502f70e92b83571a51633ad90ad601c73526", size = 4699868, upload-time = "2026-06-03T21:49:39.026Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7c/5222b7f2d5d5a0186b9ffa931e0372867539544ab3092a7e29031e0347ba/truss_transfer-0.0.43-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7014853d0ad5a44a1b7566408de476c4f5f1f063f62c01dfde5f0b2bfefa392a", size = 4139687, upload-time = "2026-06-03T21:49:28.022Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/21/388762b42fbae69afb5e317b731ace9707b44e072984b5c6a5a26af9e0da/truss_transfer-0.0.43-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:cf9965d1d21c0e2ffb24c7bd7a6c9f3c699da1d27c73a83949500e5063926eac", size = 4034240, upload-time = "2026-06-03T21:49:23.504Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/86/ab257877467e849096248f8d76eb64b3659c546398ebece03c73b4b5b2ac/truss_transfer-0.0.43-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b7e8a3cc0df83410541628ae152ba5bad2f6e2356f65aac4e8fe922879ea61d", size = 4679132, upload-time = "2026-06-03T21:49:16.962Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/9a/e20b514ce4be09d8543d1301f126c70aadb6f3d983607002fd2bb20543eb/truss_transfer-0.0.43-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1de550e95d0361899230694020ca93f16cefe6f92ff8bed43ca1b7a831306503", size = 5394408, upload-time = "2026-06-03T21:49:14.094Z" },
+    { url = "https://files.pythonhosted.org/packages/08/72/18f4cc06fe193e3d80119a12e857090f15c2286c79b12bdff75940aec276/truss_transfer-0.0.43-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:198210fa519583f792e8b6e793e81090046e17929507ecca1dac0ae9b7d9e4ff", size = 4476319, upload-time = "2026-06-03T21:49:20.255Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e4/84e2482332213d49aff3f0404f2454c048fcc615f855c57ded1b4285641a/truss_transfer-0.0.43-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:51d89992af24312a2ff78cd683fd9686378492b5c9e1740393f2077b099a9033", size = 4468112, upload-time = "2026-06-03T21:49:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/25/5015a5474ded6d965842830a70abce072beafe49b56994213f1cd14aa178/truss_transfer-0.0.43-cp38-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:24e2846dbf321c138960948d9759bb9a5dd2486eca2c0c14a0b41e62fad9ebf8", size = 4225146, upload-time = "2026-06-03T21:49:11.38Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b4/8b0d3fbca8882724c9c6396313507278947600c4c5d2888f125164126af3/truss_transfer-0.0.43-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0243ac41b84ab6fb77d01559cc8614b13c3bb0820c49972720b2b21072389c0d", size = 4646578, upload-time = "2026-06-03T21:49:31.204Z" },
+    { url = "https://files.pythonhosted.org/packages/76/29/60b60bf567f9a08ea71aff48300cf24447e7f025096e5f48926230c47cd9/truss_transfer-0.0.43-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:77206f6cef60f2ac598702e15d10d40fd7c303d901c81a46aa5ad6800a950b3a", size = 4465324, upload-time = "2026-06-03T21:49:34.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/92292c9ea821362fd72e49c55ccc86f8d789bd63cf9bbf16d1c5fa105570/truss_transfer-0.0.43-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:a996cb9afe4ebf2105a8d00c1907ce6c9b54a2d43e283f7f9f212bbdfc466dad", size = 4652589, upload-time = "2026-06-03T21:49:37.412Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/fc/56ca8a78f79d974ceb67e580103a32092be40df1f4ebe89546b093dae27b/truss_transfer-0.0.43-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9c5060e5a35de6beafed1e88fd625ddcfc923fc51f63f6894e51ac3221c72047", size = 4720148, upload-time = "2026-06-03T21:49:40.716Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6e/ebd8fa29df86ae00b4caedb20a947a93931d2bd1248afe120167e4769fe7/truss_transfer-0.0.43-cp38-abi3-win_amd64.whl", hash = "sha256:d74287637b34b06d00f4d6c3423b1a805501b0efd0f31d321f89fd8d6d162a1f", size = 3768004, upload-time = "2026-06-03T21:49:42.853Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds `examples/kimi-k2.6-lora-merge/` — a training-job recipe that merges a Loops LoRA adapter into the quantized Kimi-K2.6 base, producing a single deployable checkpoint that serves on **stock vLLM with no patches**.

## Why it's a fast, in-place merge

The Loops sampler adapter targets attention projections + `lm_head`, which the Kimi-K2.6 INT4 release stores as **BF16** (only the MoE experts are packed INT4). So the merge happens **in place on CPU** — no dequantize/requantize — and the experts + `quantization_config` are carried through untouched.

## How it works

1. `load_checkpoint_config` pulls the Loops **sampler** adapter via `LoopsCheckpoint.from_checkpoint(...)` (the user-facing loader — no raw S3 URL).
2. `WeightsSource` mirrors `moonshotai/Kimi-K2.6` to `/app/base`.
3. `merge.py` rewrites only the shards holding the adapted BF16 tensors (`W += (alpha/r)·BᵀA`) and copies everything else through.
4. Output lands in `$BT_CHECKPOINT_DIR/merged` as a complete HF checkpoint.

### Clean-checkpoint detail

safetensors writes each shard via an atomic `.tmp<random>` → rename. `merge.py` points that temp at a sibling `_merged_staging/` dir (same filesystem) and `os.replace`s the finished shard into `merged/`, so the checkpoint never contains a transient `.tmp` for the checkpoint-sync to upload and orphan.

## Notes

- Fill in `LOOPS_RUN_ID` / `LOOPS_CHECKPOINT_NAME` in `config.py` with your own run (placeholders by default).
- `merge.py` validates every adapter target lands on a BF16 `.weight` and fails loudly if any is a packed/quantized tensor (which would mean the adapter touched the MoE experts and needs the dequant→merge→requant path instead).
- Validated end-to-end on H100: merge correctness spot-checked (`W = W_base + 2·BᵀA`), and the produced checkpoint reconciles clean (no `.tmp` bloat).

https://claude.ai/code/session_01ECcRtV3ELN5MTyTK7AsKAq