### PR TITLE
feat(smoke-test): mount qwen3-0.6b base model via weights API instead of HF

### DIFF
--- a/bin/test_example.py
+++ b/bin/test_example.py
@@ -488,6 +488,7 @@ def deploy_and_infer(
         deploy_config,
         project_id=project_id,
         job_id=job_id,
+        run_id=None,
         dry_run=False,
     )
 

--- a/examples/qwen3-0.6b-axolotl/training/config.py
+++ b/examples/qwen3-0.6b-axolotl/training/config.py
@@ -1,8 +1,10 @@
 # Import necessary classes from the Baseten Training SDK
-from truss_train import definitions
+from truss_train import definitions, WeightsSource
 from truss.base import truss_config
 
 project_name = "demo/qwen3-0.6b"
+
+MODEL_MOUNT_PATH = "/mnt/user/Qwen3-0.6B"
 
 # 1. Define a base image for your training job
 BASE_IMAGE = "axolotlai/axolotl:main-20250811-py3.11-cu126-2.7.1"
@@ -19,8 +21,9 @@ training_runtime = definitions.Runtime(
         f"axolotl fetch deepspeed_configs && torchrun --nproc-per-node={NUM_GPUS} train.py",
     ],
     environment_variables={
-        # Secrets (ensure these are configured in your Baseten workspace)
-        # Include other environment variables as needed
+        # train.py seeds the HF cache from this mount so the model loads from
+        # the mirror instead of HuggingFace, while keeping its canonical repo id.
+        "MODEL_MOUNT_PATH": MODEL_MOUNT_PATH,
     },
     cache_config=definitions.CacheConfig(
         enabled=True,
@@ -45,6 +48,12 @@ my_training_job = definitions.TrainingJob(
     image=definitions.Image(base_image=BASE_IMAGE),
     compute=training_compute,
     runtime=training_runtime,
+    weights=[
+        WeightsSource(
+            source="hf://Qwen/Qwen3-0.6B",
+            mount_location=MODEL_MOUNT_PATH,
+        )
+    ],
 )
 
 

--- a/examples/qwen3-0.6b-axolotl/training/train.py
+++ b/examples/qwen3-0.6b-axolotl/training/train.py
@@ -5,6 +5,8 @@ CACHE_DIR = os.environ.get("BT_PROJECT_CACHE_DIR")
 if CACHE_DIR:
     os.environ["HF_HOME"] = CACHE_DIR
 
+# Imported after HF_HOME is set so the hub cache constants resolve to it.
+from huggingface_hub import HfApi
 from axolotl.utils.dict import DictDefault
 from axolotl.cli.config import load_cfg
 from axolotl.common.datasets import load_datasets
@@ -12,10 +14,34 @@ from axolotl.train import train
 
 OUTPUT_DIR = os.environ.get("BT_CHECKPOINT_DIR", "outputs/qwen3-0.6b")
 
+MODEL_MOUNT_PATH = os.environ["MODEL_MOUNT_PATH"]
+MODEL_ID = "Qwen/Qwen3-0.6B"
+
+
+def seed_hf_cache_from_mount(model_id: str, mount_path: str) -> None:
+    """Expose the BDN-mounted weights to HF under the canonical repo id.
+
+    Lets from_pretrained(model_id) load the weights from the mount instead of
+    downloading them, while still recording the HF repo id in the saved LoRA
+    adapter — a deployable checkpoint needs base_model to be 'namespace/model'
+    (resolved from the BDN mirror), not a local path. Recording it at train
+    time avoids the post-hoc re-sync/re-discovery race a later rewrite hits."""
+    hub = Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface")) / "hub"
+    repo_dir = hub / f"models--{model_id.replace('/', '--')}"
+    commit = HfApi().model_info(model_id).sha
+    snapshot = repo_dir / "snapshots" / commit
+    (repo_dir / "refs").mkdir(parents=True, exist_ok=True)
+    (repo_dir / "refs" / "main").write_text(commit)
+    snapshot.parent.mkdir(parents=True, exist_ok=True)
+    if not snapshot.exists():
+        snapshot.symlink_to(mount_path)
+
+
 def main():
+    seed_hf_cache_from_mount(MODEL_ID, MODEL_MOUNT_PATH)
     config = DictDefault(
         adapter="qlora",
-        base_model="Qwen/Qwen3-0.6B",
+        base_model=MODEL_ID,
         bf16=True,
         # chat_template="tokenizer_default_fallback_chatml",
 


### PR DESCRIPTION
This PR makes two changes to unblock and harden the training smoke test.

## 1. Mount qwen3-0.6b base model via the weights API (BDN)

The smoke test pulled `Qwen/Qwen3-0.6B` **directly from HuggingFace inside the training container** on every run (via axolotl resolving `base_model`). With the daily schedule plus the H100/H200 matrix, this was getting **rate-limited by HF**.

- **`config.py`** — add `WeightsSource(source="hf://Qwen/Qwen3-0.6B", mount_location="/mnt/user/Qwen3-0.6B")` to the `TrainingJob`, and pass the mount path to the container via the `MODEL_MOUNT_PATH` env var. Baseten mirrors the repo into BDN once (deduplicated at the WeightVersion level) and CSI-mounts it.
- **`train.py`** — `seed_hf_cache_from_mount()` wires the mounted weights into the HF hub cache under the canonical repo id (real commit from a cheap metadata call → `snapshots/<commit>` symlinked to the mount). `from_pretrained("Qwen/Qwen3-0.6B")` then loads from the mount (only lightweight HEADs, no 1.5 GB download) **and records the HF id in the saved LoRA adapter**, so the checkpoint is deployable — deploy resolves the base from the BDN mirror by `namespace/model` id.

  (Recording the id at train time is deliberate: a post-hoc rewrite of `adapter_config.json` loses a race — the job is COMPLETED and deployed before the re-upload + `ensure_checkpoints` re-read propagate the new base_model.)

## 2. Fix deploy-and-infer: pass `run_id`

`truss`'s `create_model_version_from_inference_template()` gained a required `run_id` positional arg, so the deploy step failed with `missing 1 required positional argument: 'run_id'` even after training completed and checkpointed. The smoke test deploys training-job checkpoints, and `_hydrate_deploy_config` raises if `run_id` is set alongside training-job checkpoints, so the correct value is `None`.

## Notes

- First run still seeds the BDN mirror from HF once; the win is on repeated runs. The dataset (`winglian/pirate-ultrachat-10k`) is still an HF pull.
- Separately, there's an **intermittent** dataset-prep failure (`FileNotFoundError` on an arrow shard under the project cache mount during axolotl's 128-process tokenization) that predates this PR and is not addressed here.