### PR TITLE
Add embeddings recipe linking NVIDIA Nemotron embed finetune

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ From data preprocessing to checkpointed and trained models, these recipes cover 
   - [Train and deploy an MNIST digit classifier with Pytorch](#train-and-deploy-an-mnist-digit-classifier-with-pytorch)
     - [Training](#training-2)
   - [Fine-tune NVIDIA Isaac-GR00T N1](#fine-tune-nvidia-isaac-gr00t-n1)
+  - [Fine-tune NVIDIA Nemotron embedding models](#fine-tune-nvidia-nemotron-embedding-models)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -208,6 +209,12 @@ truss train get_checkpoint_urls --job-id $JOB_ID
 [NVIDIA Isaac-GR00T](https://github.com/NVIDIA/Isaac-GR00T) is a ~3B Vision-Language-Action foundation model for humanoid robots. This recipe fine-tunes it on a LeRobot-format dataset. Training is pure PyTorch on pre-recorded demonstrations — no simulator or rendering stack. It defaults to a full fine-tune on a single H100; to run on a 24GB GPU (A10G), use LoRA (`--lora-rank 64`).
 
 [`recipes/isaac-groot/README.md`](recipes/isaac-groot/README.md)
+
+### Fine-tune NVIDIA Nemotron embedding models
+
+NVIDIA's [Nemotron embedding fine-tuning recipe](https://github.com/NVIDIA-NeMo/Nemotron/tree/preview/embed-finetune-recipe-2607/docs/nemotron/embed) adapts an embedding model to a domain-specific retrieval task with synthetic data generation and contrastive learning, typically gaining 5–20 points of nDCG@10 over the base model. The six-stage pipeline (SDG → data prep → fine-tune → eval → export → deploy) runs on a single 80GB GPU (H100/A100). This recipe frames how it maps onto a Baseten training job.
+
+[`recipes/embeddings/README.md`](recipes/embeddings/README.md)
 
 ## Contributing
 

--- a/recipes/embeddings/README.md
+++ b/recipes/embeddings/README.md
@@ -1,0 +1,48 @@
+# Fine-tune NVIDIA Nemotron embedding models
+
+NVIDIA's [Nemotron embedding fine-tuning recipe](https://github.com/NVIDIA-NeMo/Nemotron/tree/preview/embed-finetune-recipe-2607/docs/nemotron/embed)
+adapts an embedding model to a domain-specific retrieval task. Pre-trained
+embeddings often underperform on specialized corpora with their own terminology
+and document structure; this recipe closes that gap and typically gains **5–20
+points of nDCG@10** over the base model.
+
+The full pipeline is maintained by NVIDIA in the NeMo repo. This page frames how
+it maps onto a Baseten training job.
+
+## What it does
+
+An end-to-end, six-stage pipeline:
+
+1. **SDG** — generate synthetic query/answer pairs from your documents.
+2. **Data prep** — build training data with hard-negative mining.
+3. **Fine-tune** — train the embedding model with contrastive learning.
+4. **Eval** — measure retrieval quality with BEIR metrics (nDCG, Recall).
+5. **Export** — export the model for deployment when required.
+6. **Deploy** — serve via a Retriever NIM or vLLM.
+
+## Hardware
+
+The fine-tune stage needs a single GPU with **80GB+ VRAM** (H100 or A100), 16+
+CPU cores, 128GB+ RAM, and ~50GB of free storage. Python 3.12+.
+
+## Run it on Baseten
+
+Follow NVIDIA's recipe for the pipeline itself:
+
+**→ [NVIDIA-NeMo/Nemotron · docs/nemotron/embed](https://github.com/NVIDIA-NeMo/Nemotron/tree/preview/embed-finetune-recipe-2607/docs/nemotron/embed)**
+
+To run the fine-tune stage as a Baseten training job, wrap the recipe's install
+and training commands in a `config.py` / `run.sh` pair (see the
+[`isaac-groot`](../isaac-groot) recipe for the pattern) on a single H100, then:
+
+```bash
+truss train push config.py
+```
+
+## Notes
+
+- **Stage 0 (SDG) calls the NVIDIA API.** Set your NVIDIA API key as a
+  [Baseten secret](https://app.baseten.co/settings/secrets) and map it in
+  `config.py`.
+- The recipe lives on NVIDIA's `preview/embed-finetune-recipe-2607` branch — pin
+  to that ref so the entrypoints and CLI flags stay stable.


### PR DESCRIPTION
## What

Adds a new `recipes/embeddings/` recipe that points to NVIDIA's [Nemotron embedding fine-tuning recipe](https://github.com/NVIDIA-NeMo/Nemotron/tree/preview/embed-finetune-recipe-2607/docs/nemotron/embed) and frames how it maps onto a Baseten training job.

## Why

Embedding fine-tuning is a common ask (domain-specific retrieval). NVIDIA maintains the full six-stage pipeline (SDG → data prep → fine-tune → eval → export → deploy), so rather than vendoring code NVIDIA owns, this is a pointer recipe — same pattern used to frame the `isaac-groot` NVIDIA recipe. It adds the Baseten-relevant context: hardware (single 80GB H100/A100), how to wrap the fine-tune stage as a training job, and the NVIDIA API key secret needed for SDG.

## Changes

- `recipes/embeddings/README.md` — new pointer recipe.
- `README.md` — table of contents entry + recipe section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)