### PR TITLE
Add OmniVoice TTS fine-tuning recipe

### DIFF
--- a/examples/omnivoice-tts-finetuning/.truss_ignore
+++ b/examples/omnivoice-tts-finetuning/.truss_ignore
@@ -1,0 +1,12 @@
+# Excluded from the `truss train push` upload context (.gitignore syntax).
+# NOTE: datasets/ is intentionally NOT ignored — a bundled local dataset
+# (e.g. datasets/my_speaker, see LOCAL_DATASET_DIR) must ship with the job.
+.venv/
+__pycache__/
+*.pyc
+hf_dataset_cache/
+data/
+exp/
+config/_*.rendered.json
+# The inference truss is deployed separately with `truss push` from truss/.
+truss/

--- a/examples/omnivoice-tts-finetuning/README.md
+++ b/examples/omnivoice-tts-finetuning/README.md
@@ -1,0 +1,332 @@
+## Fine-Tuning OmniVoice
+
+[OmniVoice](https://github.com/k2-fsa/OmniVoice) is a massively multilingual (600+ languages) zero-shot TTS model built on a diffusion language-model architecture. This recipe fine-tunes it from the pretrained `k2-fsa/OmniVoice` checkpoint on a single-speaker corpus to adapt it toward a specific voice/domain.
+
+Two data sources are supported:
+
+- **A local utterance-level dataset**: a flat folder of `<id>.wav` clips plus a transcript file with one `<id><TAB><text>` line per clip. Place the folder inside this recipe directory (e.g. `datasets/my_speaker`) and it ships with the training job via `truss train push`.
+- **A HuggingFace dataset** (the default): any HF dataset that exposes a text column and an audio column. [LJ Speech](https://huggingface.co/datasets/SeanSleat/lj_speech) (~24 hours of single-speaker English, 13.1k clips) is the running example.
+
+This mirrors the [Qwen3-TTS recipe](../qwen3-tts-transformers/) but uses OmniVoice's own training stack (`omnivoice.scripts.extract_audio_tokens` + `omnivoice.cli.train`) rather than a custom SFT loop, and is adapted from the upstream [`run_finetune.sh`](https://github.com/k2-fsa/OmniVoice/blob/master/examples/run_finetune.sh).
+
+**Note:** The `run.sh` script automatically creates and uses a virtual environment (`.venv`) to avoid conflicts with system Python installations. If running scripts manually, ensure you're using a virtual environment or have the required packages installed.
+
+## Quickstart
+
+To run on Baseten, run the following command to deploy the finetuning job:
+
+```bash
+truss train push config.py
+```
+
+Everything in this directory — including any local dataset folder you place under `datasets/` — is uploaded with the job (see `.truss_ignore` for exclusions), so a bundled local dataset needs no separate upload step. For datasets much larger than a few GB, prefer uploading to S3/GCS/HF and mounting through a [`WeightsSource`](https://docs.baseten.co/training/your-own-data) instead of bundling.
+
+## Pipeline Overview
+
+Fine-tuning runs in three stages, all wired together by `run.sh`:
+
+| Stage | What it does | Tooling |
+| ----- | ------------ | ------- |
+| 0 | Parse the local dataset (or download an HF dataset) and write `train.jsonl` / `dev.jsonl` manifests | `prepare.py` |
+| 1 | Tokenize audio into WebDataset shards (`.tar` of codec tokens + `data.lst`) | `omnivoice.scripts.extract_audio_tokens` |
+| 2 | Fine-tune from the pretrained checkpoint with `accelerate` | `omnivoice.cli.train` |
+
+Unlike the Qwen3-TTS recipe, audio tokenization is a **separate stage** (Stage 1) rather than being precomputed into the manifest — this matches OmniVoice's upstream pipeline.
+
+## Local Usage Reference
+
+### 0) Prepare the dataset
+
+`prepare.py` writes the OmniVoice manifests (`train.jsonl` + `dev.jsonl`) from either a local utterance-level folder or a HuggingFace TTS dataset.
+
+**Local utterance-level dataset (`--local_dir`):**
+
+The expected layout is a flat directory of `<id>.wav` clips plus one transcript file (`*.txt` / `*.tsv`, auto-detected) with one line per clip:
+
+```text
+utt_0001	Hey. You up this late again?
+utt_0002	That's bad. Do you like to read before sleep?
+```
+
+- The delimiter is a tab (`|` also accepted). The file's encoding is auto-detected from its BOM — UTF-8, UTF-8-BOM, and UTF-16 LE/BE all work (UTF-16 with CRLF line endings, common for Windows-exported transcripts, would break a naive UTF-8 reader).
+- Transcripts get light normalization: whitespace runs collapse to single spaces and padded quotes (`" quoted title "`) lose their inner padding. Punctuation (em dashes, ellipses) is preserved as prosody cues.
+- Clips shorter than `--min_duration` (default 0.5 s) or longer than `--max_duration` (default 30 s) are dropped, as are transcript rows without a wav (and vice versa) — each with a warning.
+
+```bash
+python prepare.py \
+  --local_dir datasets/my_speaker \
+  --train_jsonl data/finetune/manifests/train.jsonl \
+  --dev_jsonl data/finetune/manifests/dev.jsonl \
+  --dev_size 50
+```
+
+**HuggingFace dataset (`--dataset_repo`):**
+
+`prepare.py` downloads the dataset and materializes the wav clips locally. For LJ Speech (`SeanSleat/lj_speech`), the relevant columns are:
+
+| Column            | Type   | Description                                                         |
+| ----------------- | ------ | ------------------------------------------------------------------- |
+| `id`              | string | Clip id, e.g. `LJ001-0001`. Used to name the extracted wav files.   |
+| `audio`           | audio  | Inline audio bytes (auto-extracted into `{cache_dir}/clips/*.wav`). |
+| `text`            | string | Raw transcript ("printed in 1462").                                 |
+| `normalized_text` | string | Numbers/dates spelled out ("printed in fourteen sixty-two").        |
+
+For LJ Speech we pass `--text_column normalized_text` because the audio matches the normalized reading.
+
+In general the script needs:
+
+- a text column (any name, picked via `--text_column`, default `text`)
+- one of: an `audio` column with embedded bytes (parquet path), or a `file_name` column pointing at a wav in the repo (AudioFolder path)
+- optionally an `id` column, used to name the extracted wavs when there is no `file_name`
+
+If your dataset is gated, make sure you're authenticated by setting your `hf_access_token` secret in the Baseten UI (or `HF_TOKEN` locally).
+
+**Download (LJ Speech):**
+
+```bash
+python prepare.py \
+  --dataset_repo SeanSleat/lj_speech \
+  --text_column normalized_text \
+  --train_jsonl data/finetune/manifests/train.jsonl \
+  --dev_jsonl data/finetune/manifests/dev.jsonl \
+  --dev_size 50 \
+  --cache_dir ./hf_dataset_cache
+```
+
+**Common options:**
+
+- `--local_dir` / `--dataset_repo` (exactly one required): local folder vs. HuggingFace dataset repo id.
+- `--transcript_file`: transcript path for `--local_dir` (default: the single `*.txt`/`*.tsv` in the folder).
+- `--min_duration` / `--max_duration`: duration filter for local clips (defaults: `0.5` / `30` seconds; `--max_duration 0` disables the upper bound).
+- `--text_column`: Transcript column for HF datasets (default: `text`; use `normalized_text` for LJ Speech).
+- `--train_jsonl` / `--dev_jsonl`: Output manifest paths.
+- `--dev_size`: Rows held out (deterministically) for the dev set (default: `50`; set `0` to skip).
+- `--max_samples`: Cap the number of clips before the split (default: all). `run.sh` only applies a cap (800) for the LJ Speech demo; local datasets use every clip.
+- `--language_id`: Language code written to every row (default: `en`).
+- `--cache_dir`: Local directory for the HF dataset snapshot (default: `./hf_dataset_cache`).
+- `--hf_token`: Override the Hugging Face token used for the download.
+- `--max_workers`: Number of concurrent file downloads (default: `32`).
+- `--source`: `auto` (default), `parquet`, or `audiofolder`. `parquet` uses HF's auto-converted shards (much faster, embeds audio inline); `audiofolder` downloads each wav separately; `auto` tries parquet first.
+
+### 1) Manifest format
+
+After `prepare.py` runs, each manifest contains one JSON object per line in OmniVoice's expected format:
+
+- `id`: unique sample id (derived from the clip file name)
+- `audio_path`: absolute path to the wav clip inside `./hf_dataset_cache/clips/...`
+- `text`: transcript corresponding to `audio_path`
+- `language_id`: language code (e.g. `en`)
+
+Example:
+
+```jsonl
+{"id":"LJ001-0001","audio_path":"/abs/path/clips/LJ001-0001.wav","text":"Printing, in the only sense with which we are at present concerned, ...","language_id":"en"}
+{"id":"LJ001-0002","audio_path":"/abs/path/clips/LJ001-0002.wav","text":"in being comparatively modern.","language_id":"en"}
+```
+
+`id`, `audio_path`, and `text` are mandatory; `language_id` is optional metadata.
+
+### 2) Tokenize audio into WebDataset shards
+
+Stage 1 converts each manifest into WebDataset shards of precomputed codec tokens using the Higgs Audio v2 tokenizer:
+
+```bash
+python -m omnivoice.scripts.extract_audio_tokens \
+  --input_jsonl data/finetune/manifests/train.jsonl \
+  --tar_output_pattern data/finetune/tokens/train/audios/shard-%06d.tar \
+  --jsonl_output_pattern data/finetune/tokens/train/txts/shard-%06d.jsonl \
+  --tokenizer_path eustlb/higgs-audio-v2-tokenizer \
+  --nj_per_gpu 3 \
+  --shuffle True
+```
+
+This writes `data/finetune/tokens/train/data.lst`, the manifest of shards referenced by `config/data_config_finetune.json`. Repeat for the `dev` split.
+
+### 3) Fine-tune
+
+Run the end-to-end pipeline (prepare + tokenize + train):
+
+```bash
+./run.sh
+```
+
+`run.sh` is preset for a single H100 on a small single-speaker corpus (a few hours of audio). Override any setting via env vars (e.g. `STEPS=3000 LEARNING_RATE=5e-6 ./run.sh`).
+
+**Data / dataset knobs:**
+
+| Variable            | Default                    | Description                                                                                    |
+| ------------------- | -------------------------- | ---------------------------------------------------------------------------------------------- |
+| `LOCAL_DATASET_DIR` | unset                      | Local utterance-level dataset folder (e.g. `datasets/my_speaker`). Unset -> HF path. |
+| `TRANSCRIPT_FILE`   | auto-detected              | Transcript file inside the local dataset folder.                                               |
+| `DATASET_REPO`      | `SeanSleat/lj_speech`      | HuggingFace dataset repo id (used only when `LOCAL_DATASET_DIR` is unset/empty).               |
+| `TEXT_COLUMN`       | `normalized_text`          | Transcript column (HF path). Use `text` for most datasets; LJ Speech uses the normalized variant. |
+| `LANGUAGE_ID`       | `en`                       | Language code stamped on every manifest row.                                                    |
+| `MAX_SAMPLES`       | all (local) / `800` (HF)   | Cap on clips. Local datasets default to every clip; the LJ demo caps at 800 (~1.5h).            |
+| `DEV_SIZE`          | `50`                       | Rows held out for the dev set. Set `0` to skip eval (run.sh renders a train-only data config).  |
+| `MAX_WORKERS`       | `32`                       | Concurrent file downloads in `prepare.py` (HF path).                                            |
+| `DATASET_SOURCE`    | `auto`                     | `auto` \| `parquet` \| `audiofolder` — how `prepare.py` materializes the wavs (HF path).        |
+| `NJ_PER_GPU`        | `3`                        | Tokenizer worker processes per GPU in Stage 1.                                                  |
+
+**Training knobs:**
+
+The bulk of the training hyperparameters live in `config/train_config_finetune.json`. The most relevant fields (see [OmniVoice docs/training.md](https://github.com/k2-fsa/OmniVoice/blob/master/docs/training.md)):
+
+| Field | Default | Description |
+| ----- | ------- | ----------- |
+| `init_from_checkpoint` | `k2-fsa/OmniVoice` | Pretrained weights to start from. |
+| `steps` | `2000` | Total training steps. Sized for a small single-speaker corpus (a couple hours of audio is roughly 75 epochs at `batch_tokens=8192`); more data supports more steps, e.g. `5000` for the full LJ Speech corpus. Watch dev loss and pick the best checkpoint rather than assuming the last one wins — small corpora overfit well before the schedule ends. |
+| `learning_rate` | `1e-5` | Peak LR. Lower than from-scratch training (`1e-4`). |
+| `batch_tokens` | `8192` | Token budget per GPU per batch (primary memory control). |
+| `eval_steps` / `save_steps` | `250` | Eval + checkpoint cadence. Kept tight so there are enough dev-loss points to select the best checkpoint on a small corpus. |
+| `attn_implementation` | `flex_attention` | Attention backend. Use `config/train_config_finetune_sdpa.json` if your GPU lacks flex_attention support. |
+
+> **SDPA and short clips.** The SDPA backend batches with length-grouped padding and drops samples outside `min_sample_tokens`..`max_sample_tokens` (flex_attention's sequence packing applies no such filter). Upstream defaults `min_sample_tokens` to 50, which would silently drop sub-second conversational utterances ("Hi.", "Bye!" — ~25-30 tokens at the codec's 25 Hz frame rate); the SDPA config here lowers it to 30 to keep them.
+
+A few of these can be overridden from `run.sh` via env vars without editing the JSON — `STEPS`, `LEARNING_RATE`, `BATCH_TOKENS`, and `INIT_FROM_CHECKPOINT` (used on Baseten to point at the mounted weights). The rendered config is written to `config/_train_config.rendered.json`.
+
+**Output / GPU knobs:**
+
+| Variable      | Default                          | Description |
+| ------------- | -------------------------------- | ----------- |
+| `OUTPUT_DIR`  | `${BT_CHECKPOINT_DIR:-exp/omnivoice_finetune}` | Where checkpoints are written. On Baseten, only `$BT_CHECKPOINT_DIR` is persisted. |
+| `GPU_IDS`     | `0`                              | GPUs to use, e.g. `0,1,2,3`. |
+| `NUM_GPUS`    | `1`                              | Number of processes for `accelerate`. |
+| `TRAIN_CONFIG`| `config/train_config_finetune.json` | Swap to `config/train_config_finetune_sdpa.json` for broader GPU compatibility. |
+
+**Common overrides:**
+
+```bash
+# Quick smoke test (smaller subset, fewer steps):
+MAX_SAMPLES=200 STEPS=500 ./run.sh
+
+# Local utterance-level dataset:
+LOCAL_DATASET_DIR=datasets/my_speaker ./run.sh
+
+# Full LJ Speech corpus:
+MAX_SAMPLES= STEPS=5000 ./run.sh
+
+# SDPA attention (if flex_attention is unsupported on your GPU):
+TRAIN_CONFIG=config/train_config_finetune_sdpa.json ./run.sh
+
+# Multi-GPU:
+GPU_IDS=0,1,2,3 NUM_GPUS=4 ./run.sh
+
+# Different HF dataset:
+DATASET_REPO=org/my-tts-dataset TEXT_COLUMN=text ./run.sh
+```
+
+Checkpoints land under `${OUTPUT_DIR}/checkpoint-<step>` (HF format: `config.json` + `model.safetensors` + tokenizer files), directly loadable with `OmniVoice.from_pretrained(...)`.
+
+> **Optimizer state is stripped.** OmniVoice's trainer also writes the AdamW optimizer state (`optimizer.bin`, ~2× the model size) into each checkpoint for training resumption. `run.sh` deletes these as checkpoints are written (and once more at the end), keeping each checkpoint to its inference-only contents. The trade-off: you can't `resume_from_checkpoint` from a stripped checkpoint. If you need resumable checkpoints, remove the `strip_optimizer_state` sweeper from `run.sh`.
+
+**Monitor with TensorBoard:**
+
+```bash
+tensorboard --logdir exp/omnivoice_finetune/tensorboard
+```
+
+### 4) Quick inference test
+
+The fine-tuned checkpoint is a drop-in OmniVoice model. Voice cloning with a short reference clip from your target speaker is the most stable mode:
+
+```python
+import soundfile as sf
+import torch
+from omnivoice.models.omnivoice import OmniVoice
+
+model = OmniVoice.from_pretrained(
+    "exp/omnivoice_finetune/checkpoint-2000",  # pick the best dev-loss step
+    device_map="cuda:0",
+    dtype=torch.float16,
+)
+
+audio = model.generate(
+    text="She said she would be here by noon.",
+    ref_audio="hf_dataset_cache/clips/LJ001-0001.wav",  # a clip from your training corpus
+    ref_text="Printing, in the only sense with which we are at present concerned, ...",
+)
+sf.write("output.wav", audio[0], model.sampling_rate)
+```
+
+Or via the CLI that ships with `omnivoice`:
+
+```bash
+omnivoice-infer \
+  --model exp/omnivoice_finetune/checkpoint-2000 \
+  --text "She said she would be here by noon." \
+  --ref_audio hf_dataset_cache/clips/LJ001-0001.wav \
+  --ref_text "Printing, in the only sense with which we are at present concerned, ..." \
+  --output output.wav
+```
+
+### 5) Deploy a fine-tuned checkpoint with Truss
+
+The `truss/` folder packages a trained checkpoint as a Baseten deployment. It uses the vLLM-Omni server (`docker_server` running `vllm serve --omni` on the `baseten/vllm-omni` image), which exposes an OpenAI-compatible `/v1/audio/speech` endpoint for voice cloning / voice design / auto voice.
+
+**Files:**
+
+- `truss/config.yaml` — Truss deployment spec (server image, GPU, checkpoint reference, start command).
+- `truss/call.py` — Minimal Python client that posts text (+ optional reference clip) and writes `output.wav`.
+
+**Point the deployment at your checkpoint**
+
+Edit `truss/config.yaml` and set `training_job_id` to the Baseten training job that produced the checkpoint, plus the relative path you want to serve:
+
+```22:28:examples/omnivoice-tts-finetuning/truss/config.yaml
+training_checkpoints:
+  download_folder: /models/training_checkpoints
+  artifact_references:
+    - training_job_id: qe79ppw # Replace with your training job ID
+      paths:
+        # OmniVoice writes checkpoint-<step> dirs; pick the step you want.
+        - "rank-0/checkpoint-2000"
+```
+
+The downloaded artifacts land under `/models/training_checkpoints/<training_job_id>/<path>` inside the container. Update the `CKPT` path in the `start_command` of the same file to match (it also symlinks the base repo's `audio_tokenizer/` into the checkpoint dir, since the trainer doesn't save it):
+
+```41:46:examples/omnivoice-tts-finetuning/truss/config.yaml
+  start_command: >-
+    sh -c '
+    CKPT=/models/training_checkpoints/qe79ppw/rank-0/checkpoint-2000;
+    ln -sfn /models/OmniVoice/audio_tokenizer "$CKPT/audio_tokenizer";
+    vllm serve "$CKPT" --host 0.0.0.0 --port 8091 --trust-remote-code --omni
+    '
+```
+
+Replace `qe79ppw` with your `training_job_id` and `checkpoint-2000` with whichever step you listed above.
+
+**Deploy**
+
+From the `examples/omnivoice-tts-finetuning/truss` directory:
+
+```bash
+truss push
+```
+
+**Call the deployed model**
+
+Once the deployment is live, grab its `MODEL_ID` and `DEPLOYMENT_ID` from the Baseten UI and edit them into `truss/call.py`:
+
+```29:30:examples/omnivoice-tts-finetuning/truss/call.py
+MODEL_ID = "..."
+DEPLOYMENT_ID = "..."
+```
+
+Then run it with your Baseten API key in the environment:
+
+```bash
+export BASETEN_API_KEY=...
+python truss/call.py
+```
+
+`call.py` POSTs the request and writes the returned WAV to `output.wav`.
+
+OmniVoice is a zero-shot voice-clone model — fine-tuning adapts the weights toward your speaker, but the voice at inference is driven by a reference clip rather than a baked-in speaker name (unlike the Qwen3-TTS recipe). So `call.py` does **voice cloning**: it sends a short reference clip from the target speaker plus its transcript on the speech request. Set `REF_AUDIO_PATH` / `REF_TEXT` to a clip from your training corpus; when unset it falls back to pulling one LJ Speech clip (+ transcript) via the HF datasets-server, so it runs without a local copy of the training data.
+
+Request body notes:
+
+- `input` (required): the text to synthesize.
+- `ref_audio` / `ref_text`: base64 wav + its transcript for voice cloning (what `call.py` sends). Omitting both falls back to "auto voice", which picks a *random* voice each call.
+- `instruct` (optional): style attributes for voice design (e.g. `"female, british accent"`).
+- `language` (optional): language name or code (e.g. `English` / `en`).
+- generation knobs (optional): `num_step`, `guidance_scale`, `speed`, `duration`.

--- a/examples/omnivoice-tts-finetuning/config.py
+++ b/examples/omnivoice-tts-finetuning/config.py
@@ -1,0 +1,66 @@
+from truss_train import definitions, WeightsSource
+from truss.base import truss_config
+
+# Use the `-devel` image (not `-runtime`): the default flex_attention backend
+# compiles its kernels at runtime via torch.compile/Inductor/Triton, which
+# needs a host C compiler (gcc) + CUDA dev headers. The slim runtime image
+# ships neither and fails with "Failed to find C compiler". If you'd rather
+# avoid runtime compilation entirely, switch run.sh to the SDPA training
+# config and the runtime image is sufficient.
+BASE_IMAGE = "pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel"
+PROJECT_NAME = "OmniVoice Finetuning (TTS)"
+
+# Pretrained OmniVoice checkpoint to fine-tune from. We mount it so the job
+# doesn't re-download it from the Hub on every run; run.sh consumes
+# INIT_FROM_CHECKPOINT to point the training config at this directory.
+INIT_MODEL = "k2-fsa/OmniVoice"
+INIT_MODEL_MOUNT = f"/app/models/{INIT_MODEL}"
+
+training_runtime = definitions.Runtime(
+    start_commands=["/bin/sh -c 'chmod +x ./run.sh && ./run.sh'"],
+    environment_variables={
+        # Specify the HF token secret in your baseten workspace for accessing
+        # your dataset (and the pretrained model if it is gated).
+        "HF_TOKEN": definitions.SecretReference(name="hf_access_token"),
+        "HF_HUB_ENABLE_HF_TRANSFER": "true",
+        # run.sh rewrites the training config's `init_from_checkpoint` to this
+        # mounted path; locally it is unset and falls back to the HF repo id.
+        "INIT_FROM_CHECKPOINT": INIT_MODEL_MOUNT,
+        # To fine-tune on a local utterance-level dataset instead of a HF
+        # repo, place a folder of <id>.wav clips plus a `<id><TAB><text>`
+        # transcript file inside this recipe directory (it ships with
+        # `truss train push`; see .truss_ignore for exclusions) and point
+        # run.sh at it (encoding is auto-detected, incl. UTF-16):
+        # "LOCAL_DATASET_DIR": "datasets/my_speaker",
+    },
+    cache_config=definitions.CacheConfig(
+        enabled=True,
+    ),
+    checkpointing_config=definitions.CheckpointingConfig(
+        enabled=True,
+    ),
+)
+
+training_compute = definitions.Compute(
+    node_count=1,
+    accelerator=truss_config.AcceleratorSpec(
+        accelerator=truss_config.Accelerator.H100,
+        count=1,
+    ),
+)
+
+training_job = definitions.TrainingJob(
+    image=definitions.Image(base_image=BASE_IMAGE),
+    compute=training_compute,
+    runtime=training_runtime,
+    weights=[
+        WeightsSource(
+            source=f"hf://{INIT_MODEL}",
+            mount_location=INIT_MODEL_MOUNT,
+        ),
+    ],
+)
+
+training_project = definitions.TrainingProject(
+    name=PROJECT_NAME, job=training_job
+)

--- a/examples/omnivoice-tts-finetuning/config/data_config_finetune.json
+++ b/examples/omnivoice-tts-finetuning/config/data_config_finetune.json
@@ -1,0 +1,12 @@
+{
+  "train": [
+    {
+      "manifest_path": ["data/finetune/tokens/train/data.lst"]
+    }
+  ],
+  "dev": [
+    {
+      "manifest_path": ["data/finetune/tokens/dev/data.lst"]
+    }
+  ]
+}

--- a/examples/omnivoice-tts-finetuning/config/train_config_finetune.json
+++ b/examples/omnivoice-tts-finetuning/config/train_config_finetune.json
@@ -1,0 +1,41 @@
+{
+  "llm_name_or_path": "Qwen/Qwen3-0.6B",
+  "audio_vocab_size": 1025,
+  "audio_mask_id": 1024,
+  "num_audio_codebook": 8,
+
+  "audio_codebook_weights": [8, 8, 6, 6, 4, 4, 2, 2],
+  "drop_cond_ratio": 0.1,
+  "prompt_ratio_range": [0.0, 0.3],
+  "mask_ratio_range": [0.0, 1.0],
+  "language_ratio": 0.8,
+  "use_pinyin_ratio": 0.0,
+  "instruct_ratio": 0.0,
+  "only_instruct_ratio": 0.0,
+
+  "resume_from_checkpoint": null,
+  "init_from_checkpoint": "k2-fsa/OmniVoice",
+
+  "attn_implementation": "flex_attention",
+
+  "learning_rate": 1e-5,
+  "weight_decay": 0.01,
+  "max_grad_norm": 1.0,
+  "steps": 2000,
+  "seed": 42,
+  "warmup_type": "ratio",
+  "warmup_ratio": 0.01,
+  "warmup_steps": 0,
+
+  "batch_tokens": 8192,
+  "gradient_accumulation_steps": 1,
+  "num_workers": 2,
+
+  "mixed_precision": "bf16",
+  "allow_tf32": true,
+
+  "logging_steps": 50,
+  "eval_steps": 250,
+  "save_steps": 250,
+  "keep_last_n_checkpoints": -1
+}

--- a/examples/omnivoice-tts-finetuning/config/train_config_finetune_sdpa.json
+++ b/examples/omnivoice-tts-finetuning/config/train_config_finetune_sdpa.json
@@ -1,0 +1,44 @@
+{
+  "llm_name_or_path": "Qwen/Qwen3-0.6B",
+  "audio_vocab_size": 1025,
+  "audio_mask_id": 1024,
+  "num_audio_codebook": 8,
+
+  "audio_codebook_weights": [8, 8, 6, 6, 4, 4, 2, 2],
+  "drop_cond_ratio": 0.1,
+  "prompt_ratio_range": [0.0, 0.3],
+  "mask_ratio_range": [0.0, 1.0],
+  "language_ratio": 0.8,
+  "use_pinyin_ratio": 0.0,
+  "instruct_ratio": 0.0,
+  "only_instruct_ratio": 0.0,
+
+  "resume_from_checkpoint": null,
+  "init_from_checkpoint": "k2-fsa/OmniVoice",
+
+  "attn_implementation": "sdpa",
+
+  "learning_rate": 1e-5,
+  "weight_decay": 0.01,
+  "max_grad_norm": 1.0,
+  "steps": 2000,
+  "seed": 42,
+  "warmup_type": "ratio",
+  "warmup_ratio": 0.01,
+  "warmup_steps": 0,
+
+  "batch_tokens": 8192,
+  "gradient_accumulation_steps": 1,
+  "num_workers": 2,
+
+  "mixed_precision": "bf16",
+  "allow_tf32": true,
+  "max_sample_tokens": 2000,
+  "min_sample_tokens": 30,
+  "max_batch_size": 64,
+
+  "logging_steps": 50,
+  "eval_steps": 250,
+  "save_steps": 250,
+  "keep_last_n_checkpoints": -1
+}

--- a/examples/omnivoice-tts-finetuning/prepare.py
+++ b/examples/omnivoice-tts-finetuning/prepare.py
@@ -1,0 +1,930 @@
+#!/usr/bin/env python3
+"""
+Produce OmniVoice-style training/dev JSONL manifests from a single-speaker TTS
+dataset. Two sources are supported:
+
+1. A HuggingFace dataset repo (``--dataset_repo``): downloaded and the wav
+   clips materialized locally (parquet fast-path with AudioFolder fallback).
+2. A local utterance-level directory (``--local_dir``): a flat folder of
+   ``<id>.wav`` clips plus a transcript file with one ``<id><TAB><text>`` line
+   per clip (``|`` also accepted as the delimiter). The transcript encoding is
+   auto-detected (UTF-8, UTF-8-BOM, UTF-16 LE/BE), so e.g. Windows-exported
+   UTF-16 files work as-is.
+
+Unlike the Qwen3-TTS recipe, OmniVoice tokenizes audio in a separate stage
+(`omnivoice.scripts.extract_audio_tokens`), so this script does NOT precompute
+audio tokens. It only produces the raw manifests that the tokenizer consumes.
+
+Pipeline:
+  HF dataset or local folder  ->  local wav files  ->  {train,dev}.jsonl
+
+Output JSONL fields (one JSON object per line), matching the format expected by
+OmniVoice's fine-tuning pipeline:
+- id:           unique sample id (derived from the clip file name / dataset id)
+- audio_path:   absolute path to the wav clip
+- text:         transcript corresponding to audio
+- language_id:  language code for the clip (e.g. `en`), constant for LJ Speech
+
+Expected source dataset schema:
+- A text column (default `text`, override with --text_column; useful for
+  datasets that provide e.g. `normalized_text` alongside `text`).
+- Either an `audio` column with embedded bytes (parquet path), or a
+  `file_name` column pointing at a wav file in the repo (AudioFolder path).
+- If neither `file_name` nor a usable `audio.path` is available, an `id`
+  column is used to name the extracted wav (e.g. `clips/<id>.wav`).
+
+Download speed strategy:
+The script first tries to download HuggingFace's auto-converted parquet
+shards (a handful of large files, much faster with `hf_transfer`). The audio
+bytes are embedded inline in the parquet rows, so we extract them locally to
+wav files and skip the per-clip HTTP roundtrips entirely. If parquet shards
+aren't available, it falls back to a two-pass AudioFolder download:
+metadata-only first, then exactly the wav clips that survived sampling.
+"""
+
+import argparse
+import codecs
+import contextlib
+import csv
+import json
+import os
+import random
+import re
+import time
+import wave
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Tuple
+
+# huggingface_hub is imported lazily inside the HF download paths so that the
+# --local_dir mode works without any HF dependencies installed.
+
+# `allow_patterns` for the metadata-only pre-pass on the AudioFolder fallback
+# path. We grab anything that could plausibly be a manifest plus README/json
+# config files (they're tiny). Wav clips are pulled in a separate, filtered
+# second pass.
+METADATA_ALLOW_PATTERNS = [
+    "metadata.csv",
+    "metadata.jsonl",
+    "*.parquet",
+    "*.json",
+    "*.md",
+    "README*",
+]
+
+
+def _ensure_hf_transfer_or_warn() -> None:
+    import importlib.util
+
+    if os.environ.get("HF_HUB_ENABLE_HF_TRANSFER", "").lower() not in ("1", "true", "yes"):
+        os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+    if importlib.util.find_spec("hf_transfer") is None:
+        print(
+            "[warn] HF_HUB_ENABLE_HF_TRANSFER=1 is set but the `hf_transfer` "
+            "package is not importable. Falling back to the slow pure-Python "
+            "downloader. Install with `pip install hf-transfer` to fix."
+        )
+        os.environ.pop("HF_HUB_ENABLE_HF_TRANSFER", None)
+
+
+def _id_from_file_name(file_name: str) -> str:
+    """Derive a stable sample id from a clip path (drop dirs + extension)."""
+    return Path(file_name).stem
+
+
+# ---------- fast path: parquet shards from refs/convert/parquet ----------
+
+
+def _try_download_parquet_shards(
+    dataset_repo: str,
+    cache_dir: Path,
+    token: Optional[str],
+    max_workers: int,
+) -> Optional[Path]:
+    """
+    Try to download HF's auto-converted parquet shards. Returns the local repo
+    root if successful, else None. Auto-convert lives on the special
+    `refs/convert/parquet` git ref and contains shards like
+    `default/train/0000.parquet`.
+    """
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.utils import (
+        EntryNotFoundError,
+        RepositoryNotFoundError,
+        RevisionNotFoundError,
+    )
+
+    parquet_root = cache_dir / "parquet"
+    parquet_root.mkdir(parents=True, exist_ok=True)
+    try:
+        path = snapshot_download(
+            repo_id=dataset_repo,
+            repo_type="dataset",
+            revision="refs/convert/parquet",
+            local_dir=str(parquet_root),
+            token=token,
+            allow_patterns=["**/*.parquet"],
+            max_workers=max_workers,
+        )
+    except (RevisionNotFoundError, EntryNotFoundError):
+        return None
+    except RepositoryNotFoundError:
+        return None
+    except Exception as e:
+        print(f"[warn] parquet shard download failed: {e}")
+        return None
+
+    if not list(Path(path).rglob("*.parquet")):
+        return None
+    return Path(path)
+
+
+def _extract_from_parquet(
+    parquet_root: Path,
+    clips_dir: Path,
+    text_column: str,
+    max_samples: Optional[int] = None,
+) -> List[dict]:
+    """
+    Materialize the embedded audio bytes from the parquet shards as local wav
+    files.
+
+    Two-pass to avoid extracting wavs we'd immediately throw away:
+      Pass 1: metadata-only scan (skips the heavy `audio` bytes column) to
+              build candidate rows, sort them by file_name, and apply
+              ``max_samples`` if set.
+      Pass 2: for each shard that still contributes a surviving row, read the
+              `audio` column and write only those wavs to disk.
+    """
+    try:
+        import pyarrow.parquet as pq
+    except ImportError as e:
+        raise RuntimeError(
+            "pyarrow is required to read parquet shards. "
+            "Install with: pip install pyarrow"
+        ) from e
+
+    clips_dir.mkdir(parents=True, exist_ok=True)
+    parquet_files = sorted(parquet_root.rglob("*.parquet"))
+    print(f"Reading {len(parquet_files)} parquet shard(s)...")
+
+    # ---- Pass 1: metadata-only scan ----
+    # We project just the columns needed to compute `file_name` and pick up
+    # `text`. Crucially we skip the `audio` column so we don't pull GBs of
+    # inline wav bytes through memory just to discard most of them.
+    candidates: List[dict] = []
+    for shard_idx, pq_file in enumerate(parquet_files):
+        col_names = pq.read_schema(pq_file).names
+
+        if "audio" not in col_names:
+            raise RuntimeError(
+                f"Parquet shard {pq_file.name} has no 'audio' column "
+                f"(found: {col_names})"
+            )
+        if text_column not in col_names:
+            raise RuntimeError(
+                f"Parquet shard {pq_file.name} has no '{text_column}' column "
+                f"(found: {col_names})"
+            )
+
+        meta_cols = [text_column]
+        for opt in ("id", "file_name"):
+            if opt in col_names and opt not in meta_cols:
+                meta_cols.append(opt)
+        meta_rows = pq.read_table(pq_file, columns=meta_cols).to_pylist()
+
+        for row_idx, record in enumerate(meta_rows):
+            text = record.get(text_column)
+            if not text:
+                continue
+
+            row_id = record.get("id")
+            if record.get("file_name"):
+                file_name = record["file_name"]
+            elif row_id:
+                file_name = f"clips/{row_id}.wav"
+            else:
+                # Deterministic fallback; ordered by (shard, in-shard index)
+                # so it's stable across runs.
+                file_name = f"clips/{shard_idx:04d}_{row_idx:06d}.wav"
+
+            candidates.append({
+                "shard_path": pq_file,
+                "row_idx": row_idx,
+                "file_name": file_name,
+                "text": text,
+            })
+
+    total_candidates = len(candidates)
+    candidates.sort(key=lambda c: c["file_name"])
+    if max_samples is not None and max_samples > 0:
+        candidates = candidates[:max_samples]
+    print(
+        f"Parquet metadata scan: {total_candidates} candidate rows"
+        + (
+            f" (selecting first {len(candidates)} after sort, "
+            f"max_samples={max_samples})"
+            if len(candidates) != total_candidates
+            else ""
+        )
+    )
+
+    # Group surviving rows by shard so each shard is read at most once.
+    by_shard: "dict[Path, List[dict]]" = {}
+    for c in candidates:
+        by_shard.setdefault(c["shard_path"], []).append(c)
+
+    # ---- Pass 2: write only the wavs we actually keep ----
+    rows: List[dict] = []
+    written = 0
+    started = time.time()
+    for pq_file, shard_cands in by_shard.items():
+        # If every selected wav for this shard already exists on disk (re-run
+        # of prepare.py with the same --max_samples), skip the parquet read
+        # entirely.
+        pending = [
+            c for c in shard_cands
+            if not (clips_dir / c["file_name"]).resolve().exists()
+        ]
+        audio_col = None
+        if pending:
+            audio_col = pq.read_table(pq_file, columns=["audio"])["audio"]
+
+        for c in shard_cands:
+            file_name = c["file_name"]
+            out_path = (clips_dir / file_name).resolve()
+            if not out_path.exists():
+                audio = audio_col[c["row_idx"]].as_py()
+                if isinstance(audio, dict):
+                    audio_bytes = audio.get("bytes")
+                else:
+                    audio_bytes = audio
+                if not audio_bytes:
+                    continue
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(out_path, "wb") as f:
+                    f.write(audio_bytes)
+                written += 1
+
+            rows.append({
+                "file_name": file_name,
+                "audio_path": str(out_path),
+                "text": c["text"],
+            })
+
+    elapsed = max(time.time() - started, 1e-3)
+    rate = written / elapsed if written else 0.0
+    print(
+        f"Extracted {len(rows)} rows ({written} new wav files written) "
+        f"in {elapsed:.1f}s ({rate:.0f} files/sec written)."
+    )
+    return rows
+
+
+# ---------- fallback path: AudioFolder (metadata + per-clip wav download) ----------
+
+
+def _iter_audiofolder_metadata(repo_root: Path) -> Iterator[dict]:
+    """
+    Yield metadata rows from the dataset snapshot for the AudioFolder layout.
+    Tries metadata.jsonl -> metadata.csv -> any *.parquet at the root.
+    """
+    jsonl_path = repo_root / "metadata.jsonl"
+    if jsonl_path.exists():
+        with jsonl_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    yield json.loads(line)
+        return
+
+    csv_path = repo_root / "metadata.csv"
+    if csv_path.exists():
+        with csv_path.open("r", encoding="utf-8", newline="") as f:
+            for row in csv.DictReader(f):
+                yield row
+        return
+
+    parquet_files = sorted(repo_root.glob("*.parquet"))
+    if parquet_files:
+        try:
+            import pyarrow.parquet as pq
+        except ImportError as e:
+            raise RuntimeError(
+                "Found parquet metadata but pyarrow is not installed. "
+                "Install with: pip install pyarrow"
+            ) from e
+        for pf in parquet_files:
+            table = pq.read_table(pf)
+            for row in table.to_pylist():
+                yield row
+        return
+
+    raise FileNotFoundError(
+        f"No metadata file (metadata.jsonl, metadata.csv, or *.parquet) "
+        f"found in {repo_root}"
+    )
+
+
+def _normalize_audiofolder_rows(
+    rows: Iterable[dict],
+    repo_root: Path,
+    text_column: str,
+) -> Iterator[dict]:
+    for row in rows:
+        file_name = row.get("file_name")
+        text = row.get(text_column)
+        if not file_name or not text:
+            continue
+        yield {
+            "file_name": file_name,
+            "audio_path": str((repo_root / file_name).resolve()),
+            "text": text,
+        }
+
+
+def _download_clips(
+    dataset_repo: str,
+    cache_dir: Path,
+    file_names: List[str],
+    token: Optional[str],
+    max_workers: int,
+) -> None:
+    from huggingface_hub import snapshot_download
+
+    if not file_names:
+        return
+    started = time.time()
+    snapshot_download(
+        repo_id=dataset_repo,
+        repo_type="dataset",
+        local_dir=str(cache_dir),
+        token=token,
+        allow_patterns=file_names,
+        max_workers=max_workers,
+    )
+    elapsed = max(time.time() - started, 1e-3)
+    print(
+        f"Pulled {len(file_names)} clip(s) in {elapsed:.1f}s "
+        f"({len(file_names) / elapsed:.0f} files/sec, max_workers={max_workers})."
+    )
+
+
+def _download_via_audiofolder(
+    dataset_repo: str,
+    cache_dir: Path,
+    token: Optional[str],
+    max_workers: int,
+    text_column: str,
+    max_samples: Optional[int] = None,
+) -> Tuple[Path, List[dict]]:
+    """
+    Two-pass AudioFolder fetch:
+      Pass 1: pull just metadata (manifests, READMEs) so we can enumerate
+              every candidate row without downloading any wavs.
+      Pass 2: sort + apply ``max_samples``, then targeted-download only the
+              wavs for the surviving rows.
+    """
+    from huggingface_hub import snapshot_download
+
+    print(f"[fallback] Fetching metadata from {dataset_repo} (AudioFolder layout)...")
+    repo_root = Path(
+        snapshot_download(
+            repo_id=dataset_repo,
+            repo_type="dataset",
+            local_dir=str(cache_dir),
+            token=token,
+            allow_patterns=METADATA_ALLOW_PATTERNS,
+            max_workers=max_workers,
+        )
+    )
+
+    rows = list(
+        _normalize_audiofolder_rows(
+            _iter_audiofolder_metadata(repo_root),
+            repo_root=repo_root,
+            text_column=text_column,
+        )
+    )
+
+    total_candidates = len(rows)
+    rows.sort(key=lambda r: r["file_name"])
+    if max_samples is not None and max_samples > 0:
+        rows = rows[:max_samples]
+    if rows and len(rows) != total_candidates:
+        print(
+            f"AudioFolder metadata scan: {total_candidates} candidate rows "
+            f"(selecting first {len(rows)} after sort, max_samples={max_samples})."
+        )
+
+    missing_files = sorted({
+        r["file_name"] for r in rows if not Path(r["audio_path"]).exists()
+    })
+    if missing_files:
+        print(
+            f"Downloading {len(missing_files)} audio clips with "
+            f"max_workers={max_workers}..."
+        )
+        _download_clips(
+            dataset_repo=dataset_repo,
+            cache_dir=cache_dir,
+            file_names=missing_files,
+            token=token,
+            max_workers=max_workers,
+        )
+
+    return repo_root, rows
+
+
+# ---------- download orchestration ----------
+
+
+def download_dataset(
+    dataset_repo: str,
+    cache_dir: Path,
+    token: Optional[str],
+    max_workers: int,
+    source: str,
+    max_samples: Optional[int],
+    text_column: str,
+    language_id: str,
+) -> List[dict]:
+    """
+    Materialize wav clips on disk and return a list of OmniVoice manifest rows:
+      {id, audio_path, text, language_id}
+    (paths absolute).
+    """
+    repo_root: Optional[Path] = None
+    rows: Optional[List[dict]] = None
+
+    if source in ("auto", "parquet"):
+        print(f"Trying parquet shard fast-path for {dataset_repo}...")
+        parquet_root = _try_download_parquet_shards(
+            dataset_repo=dataset_repo,
+            cache_dir=cache_dir,
+            token=token,
+            max_workers=max_workers,
+        )
+        if parquet_root is not None:
+            rows = _extract_from_parquet(
+                parquet_root=parquet_root,
+                clips_dir=cache_dir,
+                text_column=text_column,
+                max_samples=max_samples,
+            )
+            repo_root = cache_dir
+        else:
+            if source == "parquet":
+                raise SystemExit(
+                    "Parquet shards are not available for this dataset "
+                    "(refs/convert/parquet is empty or inaccessible). "
+                    "Re-run with --source audiofolder."
+                )
+            print("[info] No parquet shards available, falling back to AudioFolder download.")
+
+    if rows is None:
+        repo_root, rows = _download_via_audiofolder(
+            dataset_repo=dataset_repo,
+            cache_dir=cache_dir,
+            token=token,
+            max_workers=max_workers,
+            text_column=text_column,
+            max_samples=max_samples,
+        )
+
+    if not rows:
+        raise SystemExit("No usable rows found in the dataset.")
+
+    print(f"Samples: {len(rows)}")
+
+    still_missing = [r for r in rows if not Path(r["audio_path"]).exists()]
+    if still_missing:
+        raise SystemExit(
+            f"Expected audio file(s) missing after download, e.g. "
+            f"{still_missing[0]['file_name']!r}. Check --hf_token and dataset access."
+        )
+
+    print(f"Dataset cache: {repo_root}")
+
+    return [
+        {
+            "id": _id_from_file_name(row["file_name"]),
+            "audio_path": row["audio_path"],
+            "text": row["text"],
+            "language_id": language_id,
+        }
+        for row in rows
+    ]
+
+
+# ---------- local utterance-level dataset ----------
+
+
+def _decode_text_file(path: Path) -> str:
+    """Decode a text file, auto-detecting the encoding from its BOM.
+
+    Handles UTF-8, UTF-8-with-BOM, and UTF-16 LE/BE (UTF-16 with CRLF line
+    endings is common for transcript files exported from Windows tools).
+    """
+    raw = path.read_bytes()
+    if raw.startswith(codecs.BOM_UTF16_LE) or raw.startswith(codecs.BOM_UTF16_BE):
+        return raw.decode("utf-16")
+    if raw.startswith(codecs.BOM_UTF8):
+        return raw.decode("utf-8-sig")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        # BOM-less UTF-16 as a last resort.
+        return raw.decode("utf-16")
+
+
+def _normalize_transcript_text(text: str) -> str:
+    """Light, safe text cleanup for transcription artifacts.
+
+    - Collapse whitespace runs (incl. tabs/newlines) into single spaces.
+    - Remove padding inside double quotes: `" quoted title "` ->
+      `"quoted title"`. Punctuation itself is preserved (em dashes,
+      ellipses, etc. are meaningful pause/prosody cues for TTS).
+    """
+    text = re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r'" (.+?) "', r'"\1"', text)
+    return text
+
+
+def _wav_duration_seconds(path: Path) -> Optional[float]:
+    """Duration of a wav clip in seconds (None if unreadable)."""
+    try:
+        with contextlib.closing(wave.open(str(path), "rb")) as wf:
+            rate = wf.getframerate()
+            return wf.getnframes() / rate if rate else None
+    except (wave.Error, EOFError, OSError):
+        try:
+            import soundfile as sf
+
+            info = sf.info(str(path))
+            return info.frames / info.samplerate if info.samplerate else None
+        except Exception:
+            return None
+
+
+def _parse_transcript_line(line: str) -> Optional[Tuple[str, str]]:
+    """Parse one `<id><TAB><text>` (or `<id>|<text>`) transcript line."""
+    for delim in ("\t", "|"):
+        if delim in line:
+            sample_id, text = line.split(delim, 1)
+            sample_id, text = sample_id.strip(), text.strip()
+            if sample_id and text:
+                return sample_id, text
+            return None
+    return None
+
+
+def _find_transcript_file(local_dir: Path) -> Path:
+    candidates = sorted(
+        p
+        for pattern in ("*.txt", "*.tsv")
+        for p in local_dir.glob(pattern)
+    )
+    if not candidates:
+        raise SystemExit(
+            f"No transcript file (*.txt / *.tsv) found in {local_dir}. "
+            "Pass --transcript_file explicitly."
+        )
+    if len(candidates) > 1:
+        raise SystemExit(
+            f"Multiple transcript candidates in {local_dir}: "
+            f"{[c.name for c in candidates]}. Pass --transcript_file explicitly."
+        )
+    return candidates[0]
+
+
+def load_local_dataset(
+    local_dir: Path,
+    transcript_file: Optional[Path],
+    language_id: str,
+    max_samples: Optional[int],
+    min_duration: float,
+    max_duration: float,
+) -> List[dict]:
+    """
+    Build OmniVoice manifest rows from a local folder of `<id>.wav` clips plus
+    a `<id><TAB><text>` transcript file.
+    """
+    local_dir = local_dir.expanduser().resolve()
+    if not local_dir.is_dir():
+        raise SystemExit(f"--local_dir {local_dir} is not a directory.")
+
+    transcript_path = (
+        Path(transcript_file).expanduser().resolve()
+        if transcript_file
+        else _find_transcript_file(local_dir)
+    )
+    print(f"Local dataset: {local_dir}")
+    print(f"Transcript file: {transcript_path}")
+
+    wav_by_id = {p.stem: p for p in sorted(local_dir.rglob("*.wav"))}
+    if not wav_by_id:
+        raise SystemExit(f"No .wav files found under {local_dir}.")
+
+    entries: "dict[str, str]" = {}
+    skipped_lines = 0
+    for line in _decode_text_file(transcript_path).splitlines():
+        if not line.strip():
+            continue
+        parsed = _parse_transcript_line(line)
+        if parsed is None:
+            skipped_lines += 1
+            continue
+        sample_id, text = parsed
+        if sample_id in entries:
+            print(f"[warn] duplicate transcript id {sample_id!r}; keeping first.")
+            continue
+        entries[sample_id] = _normalize_transcript_text(text)
+
+    missing_wavs = sorted(set(entries) - set(wav_by_id))
+    orphan_wavs = sorted(set(wav_by_id) - set(entries))
+    if skipped_lines:
+        print(f"[warn] {skipped_lines} unparseable transcript line(s) skipped.")
+    if missing_wavs:
+        print(
+            f"[warn] {len(missing_wavs)} transcript row(s) have no wav "
+            f"(e.g. {missing_wavs[:3]}); skipping them."
+        )
+    if orphan_wavs:
+        print(
+            f"[warn] {len(orphan_wavs)} wav(s) have no transcript "
+            f"(e.g. {orphan_wavs[:3]}); skipping them."
+        )
+
+    rows: List[dict] = []
+    too_short, too_long, unreadable = [], [], []
+    total_secs = 0.0
+    for sample_id in sorted(set(entries) & set(wav_by_id)):
+        wav_path = wav_by_id[sample_id]
+        duration = _wav_duration_seconds(wav_path)
+        if duration is None:
+            unreadable.append(sample_id)
+            continue
+        if duration < min_duration:
+            too_short.append(sample_id)
+            continue
+        if max_duration > 0 and duration > max_duration:
+            too_long.append(sample_id)
+            continue
+        total_secs += duration
+        rows.append(
+            {
+                "id": sample_id,
+                "audio_path": str(wav_path),
+                "text": entries[sample_id],
+                "language_id": language_id,
+            }
+        )
+
+    for label, skipped in (
+        (f"shorter than {min_duration}s", too_short),
+        (f"longer than {max_duration}s", too_long),
+        ("unreadable", unreadable),
+    ):
+        if skipped:
+            print(
+                f"[warn] {len(skipped)} clip(s) {label} "
+                f"(e.g. {skipped[:3]}); skipping them."
+            )
+
+    if max_samples is not None and 0 < max_samples < len(rows):
+        print(f"Applying --max_samples: keeping first {max_samples} of {len(rows)} rows.")
+        rows = rows[:max_samples]
+        total_secs = sum(_wav_duration_seconds(Path(r["audio_path"])) or 0 for r in rows)
+
+    print(
+        f"Local dataset ready: {len(rows)} clips, "
+        f"{total_secs / 3600:.2f}h of audio."
+    )
+    return rows
+
+
+# ---------- manifest writing ----------
+
+
+def _write_jsonl(rows: List[dict], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def split_train_dev(
+    rows: List[dict],
+    dev_size: int,
+    seed: int,
+) -> Tuple[List[dict], List[dict]]:
+    """
+    Deterministically hold out ``dev_size`` rows for validation.
+
+    We shuffle indices with a seeded RNG (rather than slicing the head/tail)
+    because the rows are produced by a sorted pipeline (sorted by file_name),
+    and a contiguous block would skew the dev set toward one end of the corpus.
+    """
+    if dev_size <= 0:
+        return rows, []
+    if dev_size >= len(rows):
+        raise SystemExit(
+            f"--dev_size {dev_size} must be smaller than the dataset "
+            f"({len(rows)} rows)."
+        )
+    rng = random.Random(seed)
+    indices = list(range(len(rows)))
+    rng.shuffle(indices)
+    dev_idx = set(indices[:dev_size])
+    dev_rows = [rows[i] for i in sorted(dev_idx)]
+    train_rows = [row for i, row in enumerate(rows) if i not in dev_idx]
+    return train_rows, dev_rows
+
+
+# ---------- main ----------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download a HuggingFace TTS dataset and produce OmniVoice "
+            "fine-tuning JSONL manifests (train + dev)."
+        )
+    )
+    source_group = parser.add_argument_group("data source (pick exactly one)")
+    source_group.add_argument(
+        "--dataset_repo",
+        type=str,
+        default=None,
+        help="HuggingFace dataset repo id (e.g. `SeanSleat/lj_speech`).",
+    )
+    source_group.add_argument(
+        "--local_dir",
+        type=str,
+        default=None,
+        help=(
+            "Local directory of `<id>.wav` clips plus a transcript file "
+            "(one `<id><TAB><text>` line per clip). Alternative to "
+            "--dataset_repo; e.g. `datasets/my_speaker`."
+        ),
+    )
+    parser.add_argument(
+        "--transcript_file",
+        type=str,
+        default=None,
+        help=(
+            "Transcript file for --local_dir. Defaults to the single *.txt / "
+            "*.tsv file found in the directory. Encoding is auto-detected "
+            "(UTF-8 / UTF-8-BOM / UTF-16)."
+        ),
+    )
+    parser.add_argument(
+        "--min_duration",
+        type=float,
+        default=0.5,
+        help=(
+            "Drop local clips shorter than this many seconds (default: 0.5). "
+            "Very short clips can produce empty/degenerate codec-token "
+            "sequences. Only applies to --local_dir."
+        ),
+    )
+    parser.add_argument(
+        "--max_duration",
+        type=float,
+        default=30.0,
+        help=(
+            "Drop local clips longer than this many seconds (default: 30; "
+            "set 0 to disable). Only applies to --local_dir."
+        ),
+    )
+    parser.add_argument(
+        "--train_jsonl",
+        type=str,
+        default="data/finetune/manifests/train.jsonl",
+        help="Path to the output training JSONL manifest.",
+    )
+    parser.add_argument(
+        "--dev_jsonl",
+        type=str,
+        default="data/finetune/manifests/dev.jsonl",
+        help="Path to the output dev JSONL manifest (skipped if --dev_size 0).",
+    )
+    parser.add_argument("--cache_dir", type=str, default="./hf_dataset_cache")
+    parser.add_argument(
+        "--max_samples",
+        type=int,
+        default=None,
+        help="Cap on the total number of clips before the train/dev split.",
+    )
+    parser.add_argument(
+        "--dev_size",
+        type=int,
+        default=50,
+        help="Number of rows held out (deterministically) for the dev set. "
+        "Set to 0 to skip the dev manifest.",
+    )
+    parser.add_argument(
+        "--split_seed",
+        type=int,
+        default=42,
+        help="RNG seed for the deterministic train/dev split.",
+    )
+    parser.add_argument(
+        "--hf_token",
+        type=str,
+        default=os.environ.get("HF_TOKEN"),
+    )
+    parser.add_argument(
+        "--max_workers",
+        type=int,
+        default=32,
+        help=(
+            "Concurrent file downloads passed to snapshot_download. "
+            "32 is a good default; 64+ can help on fast networks (default: 32)."
+        ),
+    )
+    parser.add_argument(
+        "--source",
+        type=str,
+        default="auto",
+        choices=["auto", "parquet", "audiofolder"],
+        help=(
+            "Where to pull data from. `parquet` uses HF's auto-converted "
+            "parquet shards (much faster, embeds audio inline). `audiofolder` "
+            "downloads metadata + each wav as a separate file. `auto` tries "
+            "parquet first and falls back to audiofolder (default: auto)."
+        ),
+    )
+    parser.add_argument(
+        "--text_column",
+        type=str,
+        default="text",
+        help=(
+            "Name of the column containing the transcript. Some datasets "
+            "expose a normalized variant (e.g. LJ Speech has both `text` and "
+            "`normalized_text`); using the normalized form generally matches "
+            "the audio better (default: text)."
+        ),
+    )
+    parser.add_argument(
+        "--language_id",
+        type=str,
+        default="en",
+        help=(
+            "Language code written to every manifest row's `language_id` "
+            "field (LJ Speech is English -> `en`). OmniVoice treats this as "
+            "optional metadata (default: en)."
+        ),
+    )
+    args = parser.parse_args()
+
+    if bool(args.dataset_repo) == bool(args.local_dir):
+        raise SystemExit(
+            "Pass exactly one of --dataset_repo (HuggingFace) or "
+            "--local_dir (local utterance-level folder)."
+        )
+
+    if args.local_dir:
+        rows = load_local_dataset(
+            local_dir=Path(args.local_dir),
+            transcript_file=args.transcript_file,
+            language_id=args.language_id,
+            max_samples=args.max_samples,
+            min_duration=args.min_duration,
+            max_duration=args.max_duration,
+        )
+    else:
+        _ensure_hf_transfer_or_warn()
+
+        cache_dir = Path(args.cache_dir).expanduser().resolve()
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        rows = download_dataset(
+            dataset_repo=args.dataset_repo,
+            cache_dir=cache_dir,
+            token=args.hf_token,
+            max_workers=args.max_workers,
+            source=args.source,
+            max_samples=args.max_samples,
+            text_column=args.text_column,
+            language_id=args.language_id,
+        )
+
+    train_rows, dev_rows = split_train_dev(
+        rows, dev_size=args.dev_size, seed=args.split_seed
+    )
+
+    train_path = Path(args.train_jsonl)
+    _write_jsonl(train_rows, train_path)
+    print(f"\nWrote {len(train_rows)} rows to {train_path}")
+
+    if dev_rows:
+        dev_path = Path(args.dev_jsonl)
+        _write_jsonl(dev_rows, dev_path)
+        print(f"Wrote {len(dev_rows)} rows to {dev_path}")
+    else:
+        print("Dev manifest skipped (--dev_size 0).")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/omnivoice-tts-finetuning/requirements.txt
+++ b/examples/omnivoice-tts-finetuning/requirements.txt
@@ -1,0 +1,11 @@
+--extra-index-url https://download.pytorch.org/whl/cu128
+torch==2.8.0+cu128
+torchaudio==2.8.0+cu128
+# OmniVoice brings in transformers, accelerate, webdataset, etc. and provides
+# the omnivoice.scripts.extract_audio_tokens / omnivoice.cli.train entrypoints.
+omnivoice
+# Dataset download + wav materialization (prepare.py).
+huggingface-hub>=0.16.0
+hf-transfer>=0.1.6
+pyarrow>=14.0.0
+soundfile>=0.12.0

--- a/examples/omnivoice-tts-finetuning/run.sh
+++ b/examples/omnivoice-tts-finetuning/run.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+set -eux
+
+# Setup virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+    echo "Creating virtual environment..."
+    python3 -m venv .venv
+fi
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Install dependencies
+pip install -q -r requirements.txt
+
+# ===================== Configuration =====================
+# Data source. Two modes:
+#   1. Local utterance-level dataset (set LOCAL_DATASET_DIR): a flat folder of
+#      <id>.wav clips + a transcript file of `<id><TAB><text>` lines. Bundle
+#      the folder inside this recipe directory (e.g. datasets/my_speaker) so
+#      it ships with `truss train push`.
+#   2. HuggingFace dataset (the default; set DATASET_REPO to change it from
+#      the LJ Speech demo corpus).
+LOCAL_DATASET_DIR="${LOCAL_DATASET_DIR:-}"
+TRANSCRIPT_FILE="${TRANSCRIPT_FILE:-}"   # optional; auto-detected in the dir
+DATASET_REPO="${DATASET_REPO:-SeanSleat/lj_speech}"
+TEXT_COLUMN="${TEXT_COLUMN:-normalized_text}"
+LANGUAGE_ID="${LANGUAGE_ID:-en}"
+
+# Layout matches config/data_config_finetune.json, which points at
+# data/finetune/tokens/{train,dev}/data.lst. Keep these in sync if you edit one.
+DATA_DIR="data/finetune"
+TRAIN_JSONL="${DATA_DIR}/manifests/train.jsonl"
+DEV_JSONL="${DATA_DIR}/manifests/dev.jsonl"
+TOKEN_DIR="${DATA_DIR}/tokens"
+CACHE_DIR="./hf_dataset_cache"
+
+# Audio tokenizer used by the tokenization stage (Higgs Audio v2 codec).
+TOKENIZER_PATH="${TOKENIZER_PATH:-eustlb/higgs-audio-v2-tokenizer}"
+
+# On Baseten, $BT_CHECKPOINT_DIR is the only directory whose contents get
+# persisted by the CheckpointingConfig (see config.py). Writing checkpoints
+# anywhere else leaves them on the job's tmpfs and they're lost when the pod
+# tears down. Fall back to ./exp/omnivoice_finetune for local dev.
+OUTPUT_DIR="${BT_CHECKPOINT_DIR:-exp/omnivoice_finetune}"
+
+# GPUs. OmniVoice is a Qwen3-0.6B-based model, so a single H100 is plenty for
+# fine-tuning. Override GPU_IDS/NUM_GPUS for multi-GPU.
+GPU_IDS="${GPU_IDS:-0}"
+NUM_GPUS="${NUM_GPUS:-1}"
+
+# Training / data configs. Swap TRAIN_CONFIG to the SDPA variant if your GPU
+# does not support flex_attention.
+TRAIN_CONFIG="${TRAIN_CONFIG:-config/train_config_finetune.json}"
+DATA_CONFIG="${DATA_CONFIG:-config/data_config_finetune.json}"
+
+# Optional size / speed knobs (override via env vars when calling this script).
+# For a local dataset we train on ALL clips by default (small single-speaker
+# corpora need every minute of audio). The 800-clip cap (~1.5h) only applies
+# to the LJ Speech HF demo, where it keeps the smoke run cheap. Set
+# MAX_SAMPLES= (empty) to use the full dataset, or a number to cap it.
+if [ -n "${LOCAL_DATASET_DIR}" ]; then
+  MAX_SAMPLES="${MAX_SAMPLES-}"
+else
+  MAX_SAMPLES="${MAX_SAMPLES-800}"
+fi
+DEV_SIZE="${DEV_SIZE:-50}"
+MAX_WORKERS="${MAX_WORKERS:-32}"
+DATASET_SOURCE="${DATASET_SOURCE:-auto}"  # auto | parquet | audiofolder
+NJ_PER_GPU="${NJ_PER_GPU:-3}"             # tokenizer worker processes per GPU
+
+# When run on Baseten, config.py exports INIT_FROM_CHECKPOINT pointing at the
+# pre-mounted weights directory (e.g. /app/models/k2-fsa/OmniVoice). Outside
+# Baseten this is unset and we fall back to the HF repo id baked into
+# TRAIN_CONFIG (init_from_checkpoint: "k2-fsa/OmniVoice"). Other optional
+# overrides: STEPS, LEARNING_RATE, BATCH_TOKENS.
+# =========================================================
+
+export HF_HUB_ENABLE_HF_TRANSFER=1
+export PYTHONUNBUFFERED=1
+# Make the omnivoice package importable when running from a source checkout.
+export PYTHONPATH="$(pwd):${PYTHONPATH:-}"
+
+# ---- Stage 0: prepare OmniVoice JSONL manifests ----
+PREPARE_ARGS=(
+  --train_jsonl "${TRAIN_JSONL}"
+  --dev_jsonl "${DEV_JSONL}"
+  --language_id "${LANGUAGE_ID}"
+  --dev_size "${DEV_SIZE}"
+)
+if [ -n "${LOCAL_DATASET_DIR}" ]; then
+  echo "Stage 0: Preparing local dataset from ${LOCAL_DATASET_DIR}..."
+  PREPARE_ARGS+=(--local_dir "${LOCAL_DATASET_DIR}")
+  if [ -n "${TRANSCRIPT_FILE}" ]; then
+    PREPARE_ARGS+=(--transcript_file "${TRANSCRIPT_FILE}")
+  fi
+else
+  echo "Stage 0: Preparing dataset from ${DATASET_REPO}..."
+  PREPARE_ARGS+=(
+    --dataset_repo "${DATASET_REPO}"
+    --cache_dir "${CACHE_DIR}"
+    --text_column "${TEXT_COLUMN}"
+    --max_workers "${MAX_WORKERS}"
+    --source "${DATASET_SOURCE}"
+  )
+fi
+if [ -n "${MAX_SAMPLES}" ]; then
+  PREPARE_ARGS+=(--max_samples "${MAX_SAMPLES}")
+fi
+python prepare.py "${PREPARE_ARGS[@]}"
+
+# ---- Stage 1: tokenize audio into WebDataset shards (train + dev) ----
+echo "Stage 1: Tokenizing audio into WebDataset shards..."
+SPLIT_JSONLS=("${TRAIN_JSONL}")
+SPLIT_NAMES=("train")
+if [ "${DEV_SIZE}" -gt 0 ]; then
+  SPLIT_JSONLS+=("${DEV_JSONL}")
+  SPLIT_NAMES+=("dev")
+fi
+
+for i in "${!SPLIT_JSONLS[@]}"; do
+  split_jsonl="${SPLIT_JSONLS[$i]}"
+  split="${SPLIT_NAMES[$i]}"
+  echo "  Tokenizing ${split} from ${split_jsonl}"
+
+  CUDA_VISIBLE_DEVICES="${GPU_IDS}" \
+    python -m omnivoice.scripts.extract_audio_tokens \
+    --input_jsonl "${split_jsonl}" \
+    --tar_output_pattern "${TOKEN_DIR}/${split}/audios/shard-%06d.tar" \
+    --jsonl_output_pattern "${TOKEN_DIR}/${split}/txts/shard-%06d.jsonl" \
+    --tokenizer_path "${TOKENIZER_PATH}" \
+    --nj_per_gpu "${NJ_PER_GPU}" \
+    --shuffle True
+
+  echo "  Done. Manifest written to ${TOKEN_DIR}/${split}/data.lst"
+done
+
+# ---- Render the data config when there is no dev split ----
+# config/data_config_finetune.json references data/finetune/tokens/dev/data.lst
+# unconditionally; with DEV_SIZE=0 that manifest is never produced and training
+# would fail. Render a train-only variant instead.
+RENDERED_DATA_CONFIG="${DATA_CONFIG}"
+if [ "${DEV_SIZE}" -eq 0 ]; then
+  RENDERED_DATA_CONFIG="config/_data_config.rendered.json"
+  python - "${DATA_CONFIG}" "${RENDERED_DATA_CONFIG}" <<'PY'
+import json, sys
+
+src, dst = sys.argv[1], sys.argv[2]
+with open(src) as f:
+    cfg = json.load(f)
+cfg.pop("dev", None)
+with open(dst, "w") as f:
+    json.dump(cfg, f, indent=2)
+print(f"Wrote dev-less data config to {dst}")
+PY
+fi
+
+# ---- Render the training config (apply optional env overrides) ----
+RENDERED_TRAIN_CONFIG="${TRAIN_CONFIG}"
+if [ -n "${INIT_FROM_CHECKPOINT:-}" ] || [ -n "${STEPS:-}" ] || \
+   [ -n "${LEARNING_RATE:-}" ] || [ -n "${BATCH_TOKENS:-}" ]; then
+  RENDERED_TRAIN_CONFIG="config/_train_config.rendered.json"
+  python - "${TRAIN_CONFIG}" "${RENDERED_TRAIN_CONFIG}" <<'PY'
+import json, os, sys
+
+src, dst = sys.argv[1], sys.argv[2]
+with open(src) as f:
+    cfg = json.load(f)
+
+
+def override(key, env, cast):
+    val = os.environ.get(env)
+    if val not in (None, ""):
+        cfg[key] = cast(val)
+
+
+override("init_from_checkpoint", "INIT_FROM_CHECKPOINT", str)
+override("steps", "STEPS", int)
+override("learning_rate", "LEARNING_RATE", float)
+override("batch_tokens", "BATCH_TOKENS", int)
+
+with open(dst, "w") as f:
+    json.dump(cfg, f, indent=2)
+print(f"Wrote rendered train config to {dst}")
+PY
+fi
+
+# OmniVoice's trainer saves the AdamW optimizer state (optimizer.bin, ~2x the
+# model size) into every checkpoint via accelerator.save_state. That state is
+# only needed to *resume* training, not for inference/deployment, so we strip
+# it to keep checkpoints lean. A background sweeper deletes it as checkpoints
+# appear (so peak disk stays low during training), plus a final sweep below.
+# NOTE: with optimizer.bin removed you cannot resume from these checkpoints
+# (resume_from_checkpoint); they remain fully loadable via from_pretrained.
+strip_optimizer_state() {
+  find "${OUTPUT_DIR}" -type f -name 'optimizer*.bin' -delete 2>/dev/null || true
+}
+
+( while true; do strip_optimizer_state; sleep 30; done ) &
+SWEEPER_PID=$!
+trap 'kill "${SWEEPER_PID}" 2>/dev/null || true' EXIT
+
+# ---- Stage 2: fine-tune ----
+echo "Stage 2: Fine-tuning..."
+accelerate launch \
+  --gpu_ids "${GPU_IDS}" \
+  --num_processes "${NUM_GPUS}" \
+  -m omnivoice.cli.train \
+  --train_config "${RENDERED_TRAIN_CONFIG}" \
+  --data_config "${RENDERED_DATA_CONFIG}" \
+  --output_dir "${OUTPUT_DIR}"
+
+# Stop the sweeper and do a final pass over the last checkpoint(s).
+kill "${SWEEPER_PID}" 2>/dev/null || true
+strip_optimizer_state
+
+echo "Done. Checkpoints written under ${OUTPUT_DIR} (optimizer state stripped)"

--- a/examples/omnivoice-tts-finetuning/truss/call.py
+++ b/examples/omnivoice-tts-finetuning/truss/call.py
@@ -1,0 +1,112 @@
+"""Minimal client for a fine-tuned OmniVoice deployment on Baseten.
+
+OmniVoice is a zero-shot voice-clone model: the voice identity at inference
+comes from a short reference clip, not a speaker name baked into the weights.
+Fine-tuning adapts the model toward your speaker/domain, but the most stable
+way to reproduce the target voice is still voice cloning with a reference clip
+from your training corpus (see the OmniVoice README). Text-only requests fall
+back to "auto voice", which picks a random voice each call.
+
+For the cloned voice to match your fine-tuned speaker, set REF_AUDIO_PATH /
+REF_TEXT below to a clip (+ transcript) from your training corpus. When they
+are unset, this client falls back to pulling one LJ Speech clip via the HF
+datasets-server so it runs out of the box against the demo fine-tune.
+
+Usage:
+    export BASETEN_API_KEY=...
+    # Edit MODEL_ID and DEPLOYMENT_ID below, then:
+    python truss/call.py
+"""
+
+import base64
+import os
+from pathlib import Path
+
+import httpx
+
+BASETEN_API_KEY = os.getenv("BASETEN_API_KEY")
+MODEL_ID = "..."
+DEPLOYMENT_ID = "..."
+
+# Reference voice clip. Set REF_AUDIO_PATH to a wav from your training corpus
+# and REF_TEXT to its transcript; leave both as None to fall back to an
+# LJ Speech clip fetched from the HF datasets-server.
+REF_AUDIO_PATH = None  # e.g. "datasets/my_speaker/utt_0001.wav"
+REF_TEXT = None  # required only when REF_AUDIO_PATH is set
+
+# Which LJ Speech row to use as the reference when auto-fetching.
+DATASET_REPO = "SeanSleat/lj_speech"
+DATASET_CONFIG = "main"
+DATASET_SPLIT = "train"
+REF_INDEX = 0
+
+API_BASE = (
+    f"https://model-{MODEL_ID}.api.baseten.co/deployment/{DEPLOYMENT_ID}/sync"
+)
+
+
+def load_reference() -> tuple[bytes, str]:
+    """Return (wav_bytes, transcript) for the reference voice clip."""
+    if REF_AUDIO_PATH:
+        if not REF_TEXT:
+            raise RuntimeError("Set REF_TEXT to the transcript of REF_AUDIO_PATH.")
+        path = Path(REF_AUDIO_PATH)
+        if not path.exists():
+            raise FileNotFoundError(f"Reference audio not found: {path}")
+        return path.read_bytes(), REF_TEXT
+
+    # Fall back to one clip + transcript from the LJ Speech datasets-server.
+    rows_url = (
+        "https://datasets-server.huggingface.co/rows"
+        f"?dataset={DATASET_REPO}&config={DATASET_CONFIG}"
+        f"&split={DATASET_SPLIT}&offset={REF_INDEX}&length=1"
+    )
+    with httpx.Client(timeout=60.0) as client:
+        row = client.get(rows_url).raise_for_status().json()["rows"][0]["row"]
+        transcript = row.get("normalized_text") or row["text"]
+
+        cache_path = Path(__file__).parent / "lj_reference.wav"
+        if not cache_path.exists():
+            audio_src = row["audio"][0]["src"]
+            cache_path.write_bytes(client.get(audio_src).raise_for_status().content)
+            print(f"Cached reference clip {row['id']} -> {cache_path}")
+        return cache_path.read_bytes(), transcript
+
+
+def main() -> None:
+    if not BASETEN_API_KEY:
+        raise RuntimeError("Set BASETEN_API_KEY in the environment.")
+    if MODEL_ID == "..." or DEPLOYMENT_ID == "...":
+        raise RuntimeError("Edit MODEL_ID and DEPLOYMENT_ID in call.py.")
+
+    ref_audio, ref_text = load_reference()
+    ref_audio_b64 = base64.b64encode(ref_audio).decode("utf-8")
+
+    text = "Wow! Isn't fine-tuning this model amazing?"
+    output_path = "output.wav"
+
+    response = httpx.post(
+        f"{API_BASE}/v1/audio/speech",
+        headers={
+            "Authorization": f"Api-Key {BASETEN_API_KEY}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "input": text,
+            "language": "English",
+            "response_format": "wav",
+            "ref_audio": f"data:audio/wav;base64,{ref_audio_b64}",
+            "ref_text": ref_text,
+        },
+        timeout=300.0,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"Speech request failed ({response.status_code}): {response.text}")
+
+    with open(output_path, "wb") as f:
+        f.write(response.content)
+    print(f"Wrote {output_path} ({len(response.content):,} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/omnivoice-tts-finetuning/truss/config.yaml
+++ b/examples/omnivoice-tts-finetuning/truss/config.yaml
@@ -1,0 +1,55 @@
+model_name: OmniVoice Finetuned
+python_version: py312
+model_metadata:
+  repo_id: k2-fsa/OmniVoice
+environment_variables:
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+  OMNIVOICE_MICRO_BATCH: "1"
+  OMNIVOICE_MICRO_BATCH_MAX: "8"
+  OMNIVOICE_MICRO_BATCH_WAIT_MS: "10"
+  VLLM_OMNI_TTS_BATCH_MAX_ITEMS: "64"
+  OMNIVOICE_CUDA_GRAPH: "1"
+  OMNIVOICE_CUDA_GRAPH_BATCH_SIZES: "1,2,4,8,16"
+  OMNIVOICE_GENERATOR_DTYPE: "bfloat16"
+weights:
+  - source: "hf://k2-fsa/OmniVoice@main"
+    mount_location: "/models/OmniVoice"
+    # Only the audio_tokenizer/ (Higgs Audio v2) is needed from the base repo;
+    # the fine-tuned checkpoint supplies the LM weights + text tokenizer. The
+    # start_command below symlinks this subdir into the checkpoint dir.
+    allow_patterns: ["audio_tokenizer/*"]
+    ignore_patterns: ["*.md", "*.txt"]
+training_checkpoints:
+  download_folder: /models/training_checkpoints
+  artifact_references:
+    - training_job_id: qe79ppw # Replace with your training job ID
+      paths:
+        # OmniVoice writes checkpoint-<step> dirs; pick the step you want.
+        - "rank-0/checkpoint-5000"
+base_image:
+  image: baseten/vllm-omni:0.21.0-omnivoice
+secrets:
+  hf_access_token: null
+system_packages:
+  - sox
+  - ffmpeg
+docker_server:
+  # The training job doesn't save the audio_tokenizer/ (Higgs Audio v2) subdir
+  # that the base OmniVoice repo ships, but vLLM-Omni resolves
+  # <model>/audio_tokenizer and errors if it's missing. Symlink it from the
+  # base weights mount into the (writable) checkpoint dir before serving.
+  start_command: >-
+    sh -c '
+    CKPT=/models/training_checkpoints/qe79ppw/rank-0/checkpoint-5000;
+    ln -sfn /models/OmniVoice/audio_tokenizer "$CKPT/audio_tokenizer";
+    vllm serve "$CKPT" --host 0.0.0.0 --port 8091 --trust-remote-code --omni
+    '
+  readiness_endpoint: /health
+  liveness_endpoint: /health
+  predict_endpoint: /v1/audio/speech
+  server_port: 8091
+resources:
+  accelerator: H100
+  use_gpu: true
+runtime:
+  predict_concurrency: 64


### PR DESCRIPTION
## Summary

Adds a complete fine-tuning recipe for [OmniVoice](https://github.com/k2-fsa/OmniVoice) (multilingual zero-shot TTS, Qwen3-0.6B-based diffusion LM) under `examples/omnivoice-tts-finetuning/`, wired for Baseten Training via `truss train push config.py`.

- **Two data sources**: any HuggingFace TTS dataset (LJ Speech demo default, parquet fast-path with AudioFolder fallback), or a **local utterance-level dataset** — a flat folder of `<id>.wav` clips plus a `<id><TAB><text>` transcript file bundled under `datasets/` so it ships with the push context. Transcript encoding is auto-detected (UTF-8 / UTF-8-BOM / UTF-16 LE/BE, CRLF-safe), with light text normalization and duration filtering.
- **Three-stage pipeline** matching upstream (`prepare.py` manifests → `extract_audio_tokens` WebDataset shards → `accelerate launch -m omnivoice.cli.train`), with checkpoints written to `$BT_CHECKPOINT_DIR` and optimizer state stripped to keep them inference-sized.
- **Robustness fixes over the upstream example**: `DEV_SIZE=0` renders a train-only data config (upstream's `run_finetune.sh` breaks here), and the SDPA config lowers `min_sample_tokens` 50→30 so short conversational utterances aren't silently dropped by length-grouped batching.
- **Defaults tuned for small single-speaker corpora**: `steps=2000`, eval/save every 250 steps for dev-loss-based checkpoint selection. Interfaces verified against upstream configs, docs, and trainer source.
- **Serving**: `truss/` deploys a fine-tuned checkpoint on vLLM-Omni (`/v1/audio/speech`), plus a minimal voice-cloning client (`truss/call.py`).

## Test plan

- [x] `prepare.py` local mode smoke-tested (UTF-16 transcript parsing, quote/whitespace normalization, duration filters, orphan warnings, train/dev split)
- [x] `bash -n run.sh`, py-compile on all scripts, JSON configs validated
- [x] Config schema / CLI flags cross-checked against upstream `k2-fsa/OmniVoice` (`run_finetune.sh`, `docs/training.md`, `training/builder.py`)
- [x] End-to-end training run on Baseten (H100) with a real corpus
- [x] Deploy checkpoint via `truss/` and verify voice cloning output