### PR TITLE
Warm-start the paired Loops sampler in the RL recipes

### DIFF
--- a/recipes/loops/README.md
+++ b/recipes/loops/README.md
@@ -32,7 +32,7 @@ uv run rl/train_grpo_async.py
 uv run multiturn_rl/train_twenty_questions.py
 ```
 
-The first run provisions a trainer (and a paired sampler for the RL recipes) in your training project, which can take a few minutes. The RL recipes set `LOOPS_WARM_START_SAMPLER=1` so the sampler is provisioned in parallel with the trainer rather than at the first sampling request — if you know your script will both train and sample, this roughly halves startup time. Leave it unset in train-only scripts (like the SFT recipe) so no sampler GPU is provisioned. Subsequent runs reuse the live servers.
+The first run provisions a trainer (and a paired sampler for the RL recipes) in your training project, which can take a few minutes. The RL recipes set `LOOPS_WARM_START_SAMPLER=true` so the sampler is provisioned in parallel with the trainer rather than at the first sampling request — if you know your script will both train and sample, this roughly halves startup time. Leave it unset in train-only scripts (like the SFT recipe) so no sampler GPU is provisioned. Subsequent runs reuse the live servers.
 
 Every config field can be overridden from the command line:
 

--- a/recipes/loops/README.md
+++ b/recipes/loops/README.md
@@ -32,7 +32,7 @@ uv run rl/train_grpo_async.py
 uv run multiturn_rl/train_twenty_questions.py
 ```
 
-The first run provisions a trainer (and a paired sampler for the RL recipes) in your training project, which can take a few minutes. Subsequent runs reuse the live servers.
+The first run provisions a trainer (and a paired sampler for the RL recipes) in your training project, which can take a few minutes. The RL recipes set `LOOPS_WARM_START_SAMPLER=1` so the sampler is provisioned in parallel with the trainer rather than at the first sampling request — if you know your script will both train and sample, this roughly halves startup time. Leave it unset in train-only scripts (like the SFT recipe) so no sampler GPU is provisioned. Subsequent runs reuse the live servers.
 
 Every config field can be overridden from the command line:
 

--- a/recipes/loops/multiturn_rl/train_twenty_questions.py
+++ b/recipes/loops/multiturn_rl/train_twenty_questions.py
@@ -31,7 +31,7 @@ from env import TwentyQuestionsDatasetBuilder
 
 # Provision the paired sampler in parallel with the trainer instead of at
 # the first sampling request.
-os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
+os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "true")
 
 
 @chz.chz

--- a/recipes/loops/multiturn_rl/train_twenty_questions.py
+++ b/recipes/loops/multiturn_rl/train_twenty_questions.py
@@ -19,6 +19,7 @@ Any CLIConfig field can be overridden on the command line, e.g.:
 """
 
 import asyncio
+import os
 from datetime import datetime
 
 import chz
@@ -27,6 +28,12 @@ from tinker_cookbook import cli_utils, model_info
 from tinker_cookbook.rl import train
 
 from env import TwentyQuestionsDatasetBuilder
+
+# RL both trains and samples, so provision the paired sampler alongside the
+# trainer instead of at the first sampling request — the two cold starts
+# overlap and startup time roughly halves. Train-only scripts should leave
+# this unset so no sampler GPU is provisioned.
+os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
 
 
 @chz.chz

--- a/recipes/loops/multiturn_rl/train_twenty_questions.py
+++ b/recipes/loops/multiturn_rl/train_twenty_questions.py
@@ -29,10 +29,8 @@ from tinker_cookbook.rl import train
 
 from env import TwentyQuestionsDatasetBuilder
 
-# RL both trains and samples, so provision the paired sampler alongside the
-# trainer instead of at the first sampling request — the two cold starts
-# overlap and startup time roughly halves. Train-only scripts should leave
-# this unset so no sampler GPU is provisioned.
+# Provision the paired sampler in parallel with the trainer instead of at
+# the first sampling request.
 os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
 
 

--- a/recipes/loops/pyproject.toml
+++ b/recipes/loops/pyproject.toml
@@ -5,10 +5,12 @@ description = "Starter training recipes for the Baseten Loops SDK"
 requires-python = ">=3.13"
 dependencies = [
     "tinker-cookbook[math-rl]",
-    "baseten-loops-tinker>=0.4.0",
+    # >=0.12.0 / >=0.16.0 for LOOPS_WARM_START_SAMPLER (parallel
+    # trainer + sampler provisioning in the RL recipes).
+    "baseten-loops-tinker>=0.12.0",
     "chz",
     "wandb>=0.16.0",
-    "baseten-loops>=0.5.0",
+    "baseten-loops>=0.16.0",
 ]
 
 [tool.uv]

--- a/recipes/loops/rl/train_grpo.py
+++ b/recipes/loops/rl/train_grpo.py
@@ -24,10 +24,8 @@ from tinker_cookbook import cli_utils
 from tinker_cookbook.recipes.math_rl.math_env import Gsm8kDatasetBuilder
 from tinker_cookbook.rl import train
 
-# RL both trains and samples, so provision the paired sampler alongside the
-# trainer instead of at the first sampling request — the two cold starts
-# overlap and startup time roughly halves. Train-only scripts should leave
-# this unset so no sampler GPU is provisioned.
+# Provision the paired sampler in parallel with the trainer instead of at
+# the first sampling request.
 os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
 
 

--- a/recipes/loops/rl/train_grpo.py
+++ b/recipes/loops/rl/train_grpo.py
@@ -15,6 +15,7 @@ Any Config field can be overridden on the command line, e.g.:
 """
 
 import asyncio
+import os
 import sys
 
 import chz
@@ -22,6 +23,12 @@ import chz
 from tinker_cookbook import cli_utils
 from tinker_cookbook.recipes.math_rl.math_env import Gsm8kDatasetBuilder
 from tinker_cookbook.rl import train
+
+# RL both trains and samples, so provision the paired sampler alongside the
+# trainer instead of at the first sampling request — the two cold starts
+# overlap and startup time roughly halves. Train-only scripts should leave
+# this unset so no sampler GPU is provisioned.
+os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
 
 
 def build_config_blueprint() -> chz.Blueprint[train.Config]:

--- a/recipes/loops/rl/train_grpo.py
+++ b/recipes/loops/rl/train_grpo.py
@@ -26,7 +26,7 @@ from tinker_cookbook.rl import train
 
 # Provision the paired sampler in parallel with the trainer instead of at
 # the first sampling request.
-os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
+os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "true")
 
 
 def build_config_blueprint() -> chz.Blueprint[train.Config]:

--- a/recipes/loops/rl/train_grpo_async.py
+++ b/recipes/loops/rl/train_grpo_async.py
@@ -29,12 +29,19 @@ Any CLIConfig field can be overridden on the command line, e.g.:
 """
 
 import asyncio
+import os
 
 import chz
 
 from tinker_cookbook import cli_utils, model_info
 from tinker_cookbook.recipes.math_rl.math_env import Gsm8kDatasetBuilder
 from tinker_cookbook.rl.train import AsyncConfig, Config, main
+
+# RL both trains and samples, so provision the paired sampler alongside the
+# trainer instead of at the first sampling request — the two cold starts
+# overlap and startup time roughly halves. Train-only scripts should leave
+# this unset so no sampler GPU is provisioned.
+os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
 
 
 @chz.chz

--- a/recipes/loops/rl/train_grpo_async.py
+++ b/recipes/loops/rl/train_grpo_async.py
@@ -39,7 +39,7 @@ from tinker_cookbook.rl.train import AsyncConfig, Config, main
 
 # Provision the paired sampler in parallel with the trainer instead of at
 # the first sampling request.
-os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
+os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "true")
 
 
 @chz.chz

--- a/recipes/loops/rl/train_grpo_async.py
+++ b/recipes/loops/rl/train_grpo_async.py
@@ -37,10 +37,8 @@ from tinker_cookbook import cli_utils, model_info
 from tinker_cookbook.recipes.math_rl.math_env import Gsm8kDatasetBuilder
 from tinker_cookbook.rl.train import AsyncConfig, Config, main
 
-# RL both trains and samples, so provision the paired sampler alongside the
-# trainer instead of at the first sampling request — the two cold starts
-# overlap and startup time roughly halves. Train-only scripts should leave
-# this unset so no sampler GPU is provisioned.
+# Provision the paired sampler in parallel with the trainer instead of at
+# the first sampling request.
 os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
 
 


### PR DESCRIPTION
## What

Sets `LOOPS_WARM_START_SAMPLER=1` (via `os.environ.setdefault`, so users can still override) in the three RL recipes — `rl/train_grpo.py`, `rl/train_grpo_async.py`, `multiturn_rl/train_twenty_questions.py` — so the paired sampler is provisioned in parallel with the trainer instead of at the first sampling request, roughly halving cold-start time. The SFT recipe is untouched: train-only scripts shouldn't provision a sampler GPU. README updated to explain the trade-off.

Part of [LPS-1001](https://linear.app/baseten/issue/LPS-1001/leverage-async-rl-in-the-cookbook) (cookbook economics / async client instantiation, from [this thread](https://basetenlabs.slack.com/archives/C0BE8KE102E/p1785511416119389?thread_ts=1785441823.603069&cid=C0BE8KE102E)).

## ⚠️ Merge after the SDK release

The env var ships in basetenlabs/baseten-loops#207, releasing as `baseten-loops` 0.16.0 / `baseten-loops-tinker` 0.12.0. Pins in `recipes/loops/pyproject.toml` are bumped to those versions, but `uv.lock` can't be regenerated until they're on PyPI — once released, run `uv lock` in `recipes/loops/` on this branch, then merge. (With an older SDK the env var is simply ignored, so nothing breaks — the recipes just fall back to lazy sampler creation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)