### PR TITLE
fix(smoke-tests): don't let a log-fetch timeout mask the real failure

### DIFF
--- a/bin/test_example.py
+++ b/bin/test_example.py
@@ -29,6 +29,10 @@ from pathlib import Path
 import requests
 
 POLL_INTERVAL = 15  # seconds between status checks
+# Log dumps are best-effort diagnostics, so they get a tighter budget than the
+# operations the test depends on.
+LOG_FETCH_TIMEOUT = 120  # seconds
+TIMEOUT_RETURNCODE = 124  # conventional exit code for a timed-out command
 TERMINAL_STATUSES = {
     "TRAINING_JOB_COMPLETED",
     "TRAINING_JOB_DEPLOY_FAILED",
@@ -97,6 +101,15 @@ def request_with_retry(method, url, max_retries=3, **kwargs):
 # ---------------------------------------------------------------------------
 
 
+def _echo_cli_output(stdout: str | None, stderr: str | None) -> None:
+    if stdout:
+        for line in stdout.rstrip().split("\n"):
+            print(f"  {line}")
+    if stderr:
+        for line in stderr.rstrip().split("\n"):
+            print(f"  [stderr] {line}", file=sys.stderr)
+
+
 def run_truss_cli(
     args: list[str], check: bool = True, timeout: int = 300
 ) -> subprocess.CompletedProcess:
@@ -106,15 +119,23 @@ def run_truss_cli(
     """
     cmd = ["uv", "run", "truss"] + args + ["--non-interactive"]
     print(f"  $ {' '.join(cmd)}")
-    result = subprocess.run(
-        cmd, capture_output=True, text=True, timeout=timeout
-    )
-    if result.stdout:
-        for line in result.stdout.rstrip().split("\n"):
-            print(f"  {line}")
-    if result.stderr:
-        for line in result.stderr.rstrip().split("\n"):
-            print(f"  [stderr] {line}", file=sys.stderr)
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout
+        )
+    except subprocess.TimeoutExpired as exc:
+        # A hung CLI call must not become the reported failure. Echo whatever it
+        # emitted and hand a synthetic result back so a check=False caller (a
+        # best-effort log dump) can carry on and report the real outcome.
+        _echo_cli_output(exc.stdout, exc.stderr)
+        message = f"CLI command timed out after {timeout}s: {' '.join(cmd)}"
+        if check:
+            raise RuntimeError(message) from exc
+        print(f"  {message}")
+        return subprocess.CompletedProcess(
+            cmd, TIMEOUT_RETURNCODE, exc.stdout or "", exc.stderr or ""
+        )
+    _echo_cli_output(result.stdout, result.stderr)
     if check and result.returncode != 0:
         raise RuntimeError(
             f"CLI command failed (exit {result.returncode}): {' '.join(cmd)}"
@@ -294,6 +315,7 @@ def poll_job_status(
             run_truss_cli(
                 ["train", "logs", "--job-id", job_id, "--remote", remote],
                 check=False,
+                timeout=LOG_FETCH_TIMEOUT,
             )
             # Stop the timed-out job via CLI
             run_truss_cli(
@@ -322,6 +344,7 @@ def poll_job_status(
                 run_truss_cli(
                     ["train", "logs", "--job-id", job_id, "--remote", remote],
                     check=False,
+                    timeout=LOG_FETCH_TIMEOUT,
                 )
             return status
 


### PR DESCRIPTION
## What

Makes the smoke test report the actual training failure instead of a timeout from the log-dump command that runs afterward.

## Why

When a job reaches a terminal failure, `poll_job_status` dumps its logs via `truss train logs` for debugging. That call is best-effort (`check=False`), but `check=False` only covers a *nonzero exit* — `subprocess.run` raises `TimeoutExpired`, which propagated out of `poll_job_status` and aborted `main` before the summary was written.

So every failing run reports only this:

```
FAIL: Command '['uv', 'run', 'truss', 'train', 'logs', '--job-id', 'w5ov4mq', ...]' timed out after 300 seconds
Traceback (most recent call last):
  File ".../bin/test_example.py", line 821, in main
    final_status = poll_job_status(
subprocess.TimeoutExpired
```

and never the `TRAINING_JOB_FAILED` status and error message it had *already successfully fetched* one line earlier.

These smoke tests have been red on every scheduled run since 2026-06-23 (last green on `main`: run 28016797245), and not one of those runs named the cause. Finding it required querying Loki by hand: the training container dies with `OSError: Can't load the model for 'Qwen/Qwen3-0.6B'` after a `403 Forbidden` from the HF Xet CDN on `model.safetensors`. Same failure on both accelerators and across two clusters (neb-eunorth1-prod-1, ori-dfw-prod-1).

This PR does not fix that 403 — it makes the next occurrence of *any* failure self-diagnosing.

## How

- `run_truss_cli` catches `subprocess.TimeoutExpired`, echoes whatever the command emitted before hanging, and then either raises a clear `RuntimeError` (`check=True`, an operation the test depends on) or returns a synthetic `CompletedProcess` with exit 124 (`check=False`, a best-effort dump) so the caller carries on and reports the real outcome.
- Extracted the stdout/stderr echo into `_echo_cli_output` so the timeout path prints partial output the same way the normal path does.
- The two log dumps get `timeout=LOG_FETCH_TIMEOUT` (120s) rather than the default 300s, since they are diagnostics rather than something the test depends on. This also cuts ~3 minutes off each failing run.

## Testing

Exercised both branches by stubbing `subprocess.run` to raise `TimeoutExpired`:

```
--- check=False (best-effort log dump): must return, not raise ---
  partial log line
  CLI command timed out after 120s: uv run truss train logs --job-id w5ov4mq --non-interactive
returncode: 124 | partial output kept: 'partial log line\n'
--- check=True (depended-on op): must raise a clear error ---
RuntimeError: CLI command timed out after 30s: uv run truss train view --non-interactive
```

I have not run the full smoke test against a live remote; that needs the workflow's credentials.

## Related

- **Root cause of the hang** is fixed upstream in basetenlabs/truss#2594, which adds a wall-clock deadline to the CLI's log pagination. That fix will not reach this repo until it ships and `pyproject.toml` moves off the `truss==0.18.16` pin, which is why this harness-side guard is worth having on its own.
- The underlying HF Xet 403 needs its own fix and is unrelated to this change.