### PR TITLE
Add async multi-turn RL recipe: twenty questions with concurrent rollouts

### DIFF
--- a/recipes/loops/README.md
+++ b/recipes/loops/README.md
@@ -57,6 +57,8 @@ In `rl/train_grpo_async.py` and `multiturn_rl/train_twenty_questions_async.py`, 
 
 `max_steps_off_policy=2` is a reasonable default; raise it for more pipelining throughput, lower it to stay closer to on-policy.
 
+`train_twenty_questions_async.py` also sets `LOOPS_WARM_START_SAMPLER=true`, which makes the SDK provision the paired sampler alongside the trainer at run creation instead of at the first sampling request, so the two cold starts overlap. Leave it unset in train-only scripts (like the SFT recipe) so no sampler GPU is provisioned.
+
 ## Choosing a base model
 
 Defaults here use Qwen3.5 models, which are supported by Loops trainers and samplers. Pick the smallest model that works for your task to keep iteration fast — `Qwen/Qwen3.5-4B` is a good starting point, and `Qwen/Qwen3-0.6B` trains in minutes if you just want to validate an environment before scaling up.

--- a/recipes/loops/README.md
+++ b/recipes/loops/README.md
@@ -13,6 +13,7 @@ These recipes use [tinker-cookbook](https://pypi.org/project/tinker-cookbook/)'s
 | [`rl/train_grpo.py`](rl/train_grpo.py) | GRPO on GSM8K math problems — synchronous sample-then-train loop. |
 | [`rl/train_grpo_async.py`](rl/train_grpo_async.py) | Async GRPO with bounded off-policy sampling — rollouts and optimizer steps run concurrently. |
 | [`multiturn_rl/train_twenty_questions.py`](multiturn_rl/train_twenty_questions.py) | Multi-turn RL: the policy plays twenty questions against a frozen answerer model served by a second sampler. [`env.py`](multiturn_rl/env.py) is the template for building your own multi-turn environment. |
+| [`multiturn_rl/train_twenty_questions_async.py`](multiturn_rl/train_twenty_questions_async.py) | Async multi-turn RL: the same twenty-questions environment with rollout workers playing games continuously while the trainer takes optimizer steps. |
 
 ## Setup
 
@@ -31,6 +32,7 @@ uv run sft/train_sft.py
 uv run rl/train_grpo.py
 uv run rl/train_grpo_async.py
 uv run multiturn_rl/train_twenty_questions.py
+uv run multiturn_rl/train_twenty_questions_async.py
 ```
 
 The first run provisions a trainer (and a paired sampler for the RL recipes) in your training project, which can take a few minutes. Subsequent runs reuse the live servers.
@@ -45,7 +47,7 @@ Training metrics land in the recipe's `log_path` (under `/tmp/loops-cookbook/` b
 
 ## Async RL and off-policy bounds
 
-In `rl/train_grpo_async.py`, rollout workers generate trajectory groups continuously while the training loop consumes them — sampling never waits for the optimizer and vice versa. The cost is staleness: a rollout may have been sampled from a policy several optimizer steps old.
+In `rl/train_grpo_async.py` and `multiturn_rl/train_twenty_questions_async.py`, rollout workers generate trajectory groups continuously while the training loop consumes them — sampling never waits for the optimizer and vice versa. The cost is staleness: a rollout may have been sampled from a policy several optimizer steps old. Async mode pays off most for multi-turn tasks, where each episode takes many sequential sampler calls and a synchronous loop would leave the trainer idle for the duration of the slowest game in every batch.
 
 `max_steps_off_policy` bounds that staleness. Each trajectory group is tagged with the policy version it was sampled from; groups more than `max_steps_off_policy` steps behind the current trainer step are requeued instead of trained on. This rides on Loops' weight-versioning semantics:
 

--- a/recipes/loops/multiturn_rl/train_twenty_questions_async.py
+++ b/recipes/loops/multiturn_rl/train_twenty_questions_async.py
@@ -1,0 +1,130 @@
+# Adapted from tinker-cookbook (https://github.com/thinking-machines-lab/tinker-cookbook),
+# Copyright 2025 Thinking Machines Lab, licensed under Apache-2.0. Modified by Baseten.
+
+"""Async multi-turn RL: twenty questions with concurrent rollouts and training.
+
+Same environment as train_twenty_questions.py — the player (the policy being
+trained) asks yes/no questions and a frozen answerer model served by a
+separate Loops sampler responds — but instead of alternating between playing
+a full batch of games and training on it, rollout workers play games
+continuously while the training loop takes optimizer steps.
+
+Multi-turn episodes make async mode pay off more than single-turn tasks: a
+game takes many sequential sampler calls (one per question), so a synchronous
+loop leaves the trainer idle for the duration of the slowest game in every
+batch. It also makes off-policy staleness more likely, since a game spans
+more wall-clock time than a single completion. `max_steps_off_policy` bounds
+that staleness: every trajectory group is tagged with the policy version it
+was sampled from, and groups more than `max_steps_off_policy` optimizer steps
+behind the current trainer step are requeued instead of trained on.
+
+Set BASETEN_API_KEY and LOOPS_PROJECT_ID before running:
+
+    uv run multiturn_rl/train_twenty_questions_async.py
+
+Any CLIConfig field can be overridden on the command line, e.g.:
+
+    uv run multiturn_rl/train_twenty_questions_async.py max_steps_off_policy=4 batch_size=32
+"""
+
+import asyncio
+import os
+from datetime import datetime
+
+import chz
+
+from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook.rl import train
+
+from env import TwentyQuestionsDatasetBuilder
+
+# RL both trains and samples, so provision the paired sampler alongside the
+# trainer instead of at the first sampling request — the two cold starts
+# overlap and startup time roughly halves. Train-only scripts should leave
+# this unset so no sampler GPU is provisioned.
+os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
+
+
+@chz.chz
+class CLIConfig:
+    model_name: str = "Qwen/Qwen3.5-4B"
+    # Non-thinking renderer: questions are capped at max_tokens=20, which a
+    # thinking renderer would spend entirely on truncated reasoning.
+    renderer_name: str | None = "qwen3_5_disable_thinking"
+    group_size: int = 8
+    num_epochs: int = 100
+    batch_size: int = 64
+    learning_rate: float = 3e-5
+    max_tokens: int = 20
+    eval_every: int = 5
+    save_every: int = 20
+    wandb_project: str | None = None
+    wandb_name: str | None = None
+    log_path: str | None = None
+    answerer_base_model: str = "Qwen/Qwen3.5-0.8B"
+
+    # Trajectory groups sampled more than this many optimizer steps behind
+    # the current policy are requeued rather than trained on. Multi-turn
+    # games go stale more often than single completions, so raising this
+    # trades on-policy fidelity for fewer requeues.
+    max_steps_off_policy: int = 2
+
+    behavior_if_log_dir_exists: cli_utils.LogdirBehavior = "ask"
+
+    max_steps: int | None = None
+
+
+def build_config(cli_config: CLIConfig) -> train.Config:
+    model_name = cli_config.model_name
+    renderer_name = (
+        cli_config.renderer_name
+        or model_info.get_recommended_renderer_name(cli_config.model_name)
+    )
+
+    date_and_time = datetime.now().strftime("%Y-%m-%d-%H-%M")
+    run_name = f"{model_name}-{cli_config.group_size}group-{cli_config.batch_size}batch-{cli_config.learning_rate}lr-{date_and_time}"
+    if cli_config.log_path is not None:
+        log_path = cli_config.log_path
+    else:
+        log_path = f"/tmp/loops-cookbook/twenty-questions-async/{run_name}"
+    if cli_config.wandb_name is not None:
+        wandb_name = cli_config.wandb_name
+    else:
+        wandb_name = run_name
+
+    dataset_builder = TwentyQuestionsDatasetBuilder(
+        batch_size=cli_config.batch_size,
+        model_name_for_tokenizer=model_name,
+        renderer_name=renderer_name,
+        group_size=cli_config.group_size,
+        num_epochs=cli_config.num_epochs,
+        answerer_base_model=cli_config.answerer_base_model,
+    )
+
+    return train.Config(
+        model_name=model_name,
+        renderer_name=renderer_name,
+        log_path=log_path,
+        dataset_builder=dataset_builder,
+        learning_rate=cli_config.learning_rate,
+        max_tokens=cli_config.max_tokens,
+        eval_every=cli_config.eval_every,
+        save_every=cli_config.save_every,
+        wandb_project=cli_config.wandb_project,
+        wandb_name=wandb_name,
+        max_steps=cli_config.max_steps,
+        async_config=train.AsyncConfig(
+            max_steps_off_policy=cli_config.max_steps_off_policy,
+            groups_per_batch=cli_config.batch_size,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    cli_config = chz.entrypoint(CLIConfig)
+    config = build_config(cli_config)
+    # Avoid clobbering log dir from your previous run:
+    cli_utils.check_log_dir(
+        config.log_path, behavior_if_exists=cli_config.behavior_if_log_dir_exists
+    )
+    asyncio.run(train.main(config))

--- a/recipes/loops/multiturn_rl/train_twenty_questions_async.py
+++ b/recipes/loops/multiturn_rl/train_twenty_questions_async.py
@@ -38,10 +38,8 @@ from tinker_cookbook.rl import train
 
 from env import TwentyQuestionsDatasetBuilder
 
-# RL both trains and samples, so provision the paired sampler alongside the
-# trainer instead of at the first sampling request — the two cold starts
-# overlap and startup time roughly halves. Train-only scripts should leave
-# this unset so no sampler GPU is provisioned.
+# Provision the paired sampler in parallel with the trainer instead of at
+# the first sampling request.
 os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
 
 
@@ -64,9 +62,7 @@ class CLIConfig:
     answerer_base_model: str = "Qwen/Qwen3.5-0.8B"
 
     # Trajectory groups sampled more than this many optimizer steps behind
-    # the current policy are requeued rather than trained on. Multi-turn
-    # games go stale more often than single completions, so raising this
-    # trades on-policy fidelity for fewer requeues.
+    # the current policy are requeued rather than trained on.
     max_steps_off_policy: int = 2
 
     behavior_if_log_dir_exists: cli_utils.LogdirBehavior = "ask"

--- a/recipes/loops/multiturn_rl/train_twenty_questions_async.py
+++ b/recipes/loops/multiturn_rl/train_twenty_questions_async.py
@@ -40,7 +40,7 @@ from env import TwentyQuestionsDatasetBuilder
 
 # Provision the paired sampler in parallel with the trainer instead of at
 # the first sampling request.
-os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "1")
+os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "true")
 
 
 @chz.chz


### PR DESCRIPTION
> [!NOTE]
> Re-opens #127, which was accidentally merged into its stacked base branch (`shreya/bump-baseten-loops-lock`) after #128 had already landed on main — so its changes never reached main. Same branch, same diff, now targeting main.

## What

Adds `multiturn_rl/train_twenty_questions_async.py` — the async variant of the existing twenty-questions recipe, using the same `env.py` environment and answerer setup, but with `AsyncConfig` so rollout workers play games continuously while the trainer takes optimizer steps (the pattern `rl/train_grpo_async.py` established for single-turn RL). README table, run list, and async section updated.

The recipe sets `LOOPS_WARM_START_SAMPLER=true` so the paired sampler is provisioned alongside the trainer at run creation (basetenlabs/baseten-loops#207) instead of at the first sampling request — RL both trains and samples, so this overlaps the two cold starts.

This is item 1 from [Raymond's thread](https://basetenlabs.slack.com/archives/C0BE8KE102E/p1785511416119389?thread_ts=1785441823.603069&cid=C0BE8KE102E) ("Twenty questions async or some other multiturn async rl example") for [LPS-1001](https://linear.app/baseten/issue/LPS-1001/leverage-async-rl-in-the-cookbook); item 2 (async client instantiation) is the SDK PR + #128.

## Why multi-turn async specifically

Multi-turn is where async mode pays off most: each episode is many sequential sampler calls (one per question), so the synchronous loop leaves the trainer idle for the duration of the slowest game in every batch. It also makes off-policy staleness more likely (a game spans more wall-clock time than a single completion), so the recipe exposes `max_steps_off_policy`.

## Testing

Validated with a full live run on the released stack (baseten-loops 0.16.0, `Qwen/Qwen3.5-4B`, `max_steps=10`): completed successfully end-to-end — held-out test reward went 0.045 (baseline) → 0.105 (step 5) → **0.129 (step 10)** over 1088-episode evals, train steps ~283s at ~11k tok/s, final checkpoints saved (`bt://loops:8w6jxyq/weights/final`). `LOOPS_WARM_START_SAMPLER` provisioned the paired sampler at run creation as designed, and rerunning with `LOOPS_REUSE_FROM_RUN_ID` attached to the warm trainer in ~1s (vs 220s cold). A 35B run remains blocked on 8×B200 capacity in the org's cluster.

Config-construction also verified against the installed tinker-cookbook: `build_config(CLIConfig())` produces `Config` with `AsyncConfig(max_steps_off_policy=2, groups_per_batch=64)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
