### PR TITLE
fix: pass run_id to create_model_version_from_inference_template in smoke test

### DIFF
--- a/bin/test_example.py
+++ b/bin/test_example.py
@@ -488,6 +488,7 @@ def deploy_and_infer(
         deploy_config,
         project_id=project_id,
         job_id=job_id,
+        run_id=None,
         dry_run=False,
     )
 


### PR DESCRIPTION
## Summary

The Training Platform Smoke Tests have failed on every scheduled run since the truss `0.16.0 -> 0.18.16` bump (441085c). Training and checkpoint validation pass; the run dies at the checkpoint-deploy step with:

```
create_model_version_from_inference_template() missing 1 required positional argument: 'run_id'
```

truss 0.18.16 added a required `run_id` parameter to `create_model_version_from_inference_template` (for Loops support). This passes `run_id=None`, which is the non-Loops path.

Failing run: https://github.com/basetenlabs/ml-cookbook/actions/runs/32000698693 (both H100 and H200 jobs, identical error in the summary artifacts).

## Testing

Verified the call binds against truss 0.18.16's signature:
`(remote_provider, checkpoint_deploy_config, project_id, job_id, run_id, dry_run, is_loops_command=False)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)