### PR TITLE
Add async math RL recipe on DeepMath

### DIFF
--- a/recipes/loops/README.md
+++ b/recipes/loops/README.md
@@ -12,6 +12,7 @@ These recipes use [tinker-cookbook](https://pypi.org/project/tinker-cookbook/)'s
 | [`sft/train_sft_glm.py`](sft/train_sft_glm.py) | SFT for [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2-FP8) — a Loops-supported model tinker-cookbook doesn't know. Shows the bring-your-own-model pattern: a custom renderer matching GLM's chat template (verified token-for-token against `apply_chat_template` before any GPU spend), registered via tinker-cookbook's renderer/tokenizer registries. |
 | [`rl/train_grpo.py`](rl/train_grpo.py) | GRPO on GSM8K math problems — synchronous sample-then-train loop. |
 | [`rl/train_grpo_async.py`](rl/train_grpo_async.py) | Async GRPO with bounded off-policy sampling — rollouts and optimizer steps run concurrently. |
+| [`rl/train_math_async.py`](rl/train_math_async.py) | Async RL on [DeepMath](https://huggingface.co/datasets/zwhe99/DeepMath-103K) — combines bounded off-policy training with warm-start sampler provisioning, so long variable-length solutions never stall the trainer. |
 | [`multiturn_rl/train_twenty_questions.py`](multiturn_rl/train_twenty_questions.py) | Multi-turn RL: the policy plays twenty questions against a frozen answerer model served by a second sampler. [`env.py`](multiturn_rl/env.py) is the template for building your own multi-turn environment. |
 | [`multiturn_rl/train_twenty_questions_async.py`](multiturn_rl/train_twenty_questions_async.py) | Async multi-turn RL: the same twenty-questions environment with rollout workers playing games continuously while the trainer takes optimizer steps. |
 
@@ -31,6 +32,7 @@ uv sync
 uv run sft/train_sft.py
 uv run rl/train_grpo.py
 uv run rl/train_grpo_async.py
+uv run rl/train_math_async.py
 uv run multiturn_rl/train_twenty_questions.py
 uv run multiturn_rl/train_twenty_questions_async.py
 ```
@@ -47,7 +49,7 @@ Training metrics land in the recipe's `log_path` (under `/tmp/loops-cookbook/` b
 
 ## Async RL and off-policy bounds
 
-In `rl/train_grpo_async.py` and `multiturn_rl/train_twenty_questions_async.py`, rollout workers generate trajectory groups continuously while the training loop consumes them — sampling never waits for the optimizer and vice versa. The cost is staleness: a rollout may have been sampled from a policy several optimizer steps old. Async mode pays off most for multi-turn tasks, where each episode takes many sequential sampler calls and a synchronous loop would leave the trainer idle for the duration of the slowest game in every batch.
+In `rl/train_grpo_async.py`, `rl/train_math_async.py`, and `multiturn_rl/train_twenty_questions_async.py`, rollout workers generate trajectory groups continuously while the training loop consumes them — sampling never waits for the optimizer and vice versa. The cost is staleness: a rollout may have been sampled from a policy several optimizer steps old. Async mode pays off most when rollout wall-clock varies widely across a batch — multi-turn tasks, where each episode takes many sequential sampler calls, and long-form reasoning tasks like DeepMath, where solution length spans a wide range — since a synchronous loop would leave the trainer idle for the duration of the slowest rollout in every batch.
 
 `max_steps_off_policy` bounds that staleness. Each trajectory group is tagged with the policy version it was sampled from; groups more than `max_steps_off_policy` steps behind the current trainer step are requeued instead of trained on. This rides on Loops' weight-versioning semantics:
 
@@ -57,7 +59,7 @@ In `rl/train_grpo_async.py` and `multiturn_rl/train_twenty_questions_async.py`, 
 
 `max_steps_off_policy=2` is a reasonable default; raise it for more pipelining throughput, lower it to stay closer to on-policy.
 
-`train_twenty_questions_async.py` also sets `LOOPS_WARM_START_SAMPLER=true`, which makes the SDK provision the paired sampler alongside the trainer at run creation instead of at the first sampling request, so the two cold starts overlap. Leave it unset in train-only scripts (like the SFT recipe) so no sampler GPU is provisioned.
+`train_twenty_questions_async.py` and `train_math_async.py` also set `LOOPS_WARM_START_SAMPLER=true`, which makes the SDK provision the paired sampler alongside the trainer at run creation instead of at the first sampling request, so the two cold starts overlap. Leave it unset in train-only scripts (like the SFT recipe) so no sampler GPU is provisioned.
 
 ## Choosing a base model
 

--- a/recipes/loops/rl/train_math_async.py
+++ b/recipes/loops/rl/train_math_async.py
@@ -1,0 +1,115 @@
+# Adapted from tinker-cookbook (https://github.com/thinking-machines-lab/tinker-cookbook),
+# Copyright 2025 Thinking Machines Lab, licensed under Apache-2.0. Modified by Baseten.
+
+"""Async math RL on DeepMath with warm-start sampler provisioning.
+
+Combines the two async mechanisms in this cookbook:
+
+- **Async RL** (as in train_grpo_async.py): rollout workers generate math
+  solutions continuously against the Loops sampler while the training loop
+  takes optimizer steps concurrently, instead of alternating sample/train
+  phases. Off-policy staleness is bounded by `max_steps_off_policy` — every
+  trajectory group is tagged with the policy version it was sampled from, and
+  groups more than that many optimizer steps behind the current trainer step
+  are requeued instead of trained on.
+
+- **Asynchronous instantiation** (as in
+  multiturn_rl/train_twenty_questions_async.py): `LOOPS_WARM_START_SAMPLER`
+  provisions the paired sampler in parallel with the trainer instead of at the
+  first sampling request, so neither deployment waits on the other before the
+  first rollout.
+
+DeepMath problems are harder than GSM8K and solutions are long, so rollout
+wall-clock varies widely across a batch — exactly the regime where async mode
+pays off: the trainer never idles waiting for the slowest solution.
+
+Set BASETEN_API_KEY before running:
+
+    uv run rl/train_math_async.py
+
+Any CLIConfig field can be overridden on the command line, e.g.:
+
+    uv run rl/train_math_async.py max_steps_off_policy=4 groups_per_batch=32
+"""
+
+import asyncio
+import os
+
+import chz
+
+from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook.recipes.math_rl.math_env import DeepMathDatasetBuilder
+from tinker_cookbook.rl.train import AsyncConfig, Config, main
+
+# Provision the paired sampler in parallel with the trainer instead of at
+# the first sampling request.
+os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "true")
+
+
+@chz.chz
+class CLIConfig:
+    model_name: str = "Qwen/Qwen3.5-4B"
+    lora_rank: int = 32
+    renderer_name: str | None = None
+
+    group_size: int = 16
+    groups_per_batch: int = 64
+    learning_rate: float = 4e-5
+    # DeepMath solutions are long chains of reasoning; don't cap them the way
+    # the GSM8K recipe does.
+    max_tokens: int = 2048
+
+    # Trajectory groups sampled more than this many optimizer steps behind
+    # the current policy are requeued rather than trained on.
+    max_steps_off_policy: int = 2
+
+    log_path: str = "/tmp/loops-cookbook/math_async"
+    wandb_project: str | None = None
+    eval_every: int = 0
+    save_every: int = 20
+    max_steps: int | None = None
+    seed: int = 0
+
+    behavior_if_log_dir_exists: cli_utils.LogdirBehavior = "ask"
+
+
+def build_config(cli_config: CLIConfig) -> Config:
+    renderer_name = (
+        cli_config.renderer_name
+        or model_info.get_recommended_renderer_name(cli_config.model_name)
+    )
+    builder = DeepMathDatasetBuilder(
+        batch_size=cli_config.groups_per_batch,
+        group_size=cli_config.group_size,
+        renderer_name=renderer_name,
+        model_name_for_tokenizer=cli_config.model_name,
+        seed=cli_config.seed,
+    )
+
+    return Config(
+        model_name=cli_config.model_name,
+        lora_rank=cli_config.lora_rank,
+        renderer_name=renderer_name,
+        log_path=cli_config.log_path,
+        dataset_builder=builder,
+        learning_rate=cli_config.learning_rate,
+        max_tokens=cli_config.max_tokens,
+        wandb_project=cli_config.wandb_project,
+        eval_every=cli_config.eval_every,
+        save_every=cli_config.save_every,
+        max_steps=cli_config.max_steps,
+        async_config=AsyncConfig(
+            max_steps_off_policy=cli_config.max_steps_off_policy,
+            groups_per_batch=cli_config.groups_per_batch,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    cli_config = chz.entrypoint(CLIConfig)
+    config = build_config(cli_config)
+    # Avoid clobbering log dir from your previous run:
+    cli_utils.check_log_dir(
+        config.log_path, behavior_if_exists=cli_config.behavior_if_log_dir_exists
+    )
+    asyncio.run(main(config))

--- a/recipes/loops/rl/train_math_async.py
+++ b/recipes/loops/rl/train_math_async.py
@@ -1,27 +1,12 @@
 # Adapted from tinker-cookbook (https://github.com/thinking-machines-lab/tinker-cookbook),
 # Copyright 2025 Thinking Machines Lab, licensed under Apache-2.0. Modified by Baseten.
 
-"""Async math RL on DeepMath with warm-start sampler provisioning.
+"""Async math RL on DeepMath.
 
-Combines the two async mechanisms in this cookbook:
-
-- **Async RL** (as in train_grpo_async.py): rollout workers generate math
-  solutions continuously against the Loops sampler while the training loop
-  takes optimizer steps concurrently, instead of alternating sample/train
-  phases. Off-policy staleness is bounded by `max_steps_off_policy` — every
-  trajectory group is tagged with the policy version it was sampled from, and
-  groups more than that many optimizer steps behind the current trainer step
-  are requeued instead of trained on.
-
-- **Asynchronous instantiation** (as in
-  multiturn_rl/train_twenty_questions_async.py): `LOOPS_WARM_START_SAMPLER`
-  provisions the paired sampler in parallel with the trainer instead of at the
-  first sampling request, so neither deployment waits on the other before the
-  first rollout.
-
-DeepMath problems are harder than GSM8K and solutions are long, so rollout
-wall-clock varies widely across a batch — exactly the regime where async mode
-pays off: the trainer never idles waiting for the slowest solution.
+As in train_grpo_async.py, rollouts and optimizer steps run concurrently
+instead of alternating, with `max_steps_off_policy` bounding how stale a
+trajectory group may be. DeepMath solutions are long and vary widely in
+length, so the trainer never idles waiting for the slowest one.
 
 Set BASETEN_API_KEY before running:
 
@@ -41,8 +26,7 @@ from tinker_cookbook import cli_utils, model_info
 from tinker_cookbook.recipes.math_rl.math_env import DeepMathDatasetBuilder
 from tinker_cookbook.rl.train import AsyncConfig, Config, main
 
-# Provision the paired sampler in parallel with the trainer instead of at
-# the first sampling request.
+# Provision the paired sampler alongside the trainer instead of at first use.
 os.environ.setdefault("LOOPS_WARM_START_SAMPLER", "true")
 
 
@@ -55,12 +39,10 @@ class CLIConfig:
     group_size: int = 16
     groups_per_batch: int = 64
     learning_rate: float = 4e-5
-    # DeepMath solutions are long chains of reasoning; don't cap them the way
-    # the GSM8K recipe does.
+    # DeepMath solutions are long; don't cap them like the GSM8K recipes do.
     max_tokens: int = 2048
 
-    # Trajectory groups sampled more than this many optimizer steps behind
-    # the current policy are requeued rather than trained on.
+    # Max optimizer steps a trajectory group may lag the current policy.
     max_steps_off_policy: int = 2
 
     log_path: str = "/tmp/loops-cookbook/math_async"


### PR DESCRIPTION
## What

Adds `recipes/loops/rl/train_math_async.py`: async RL on [DeepMath-103K](https://huggingface.co/datasets/zwhe99/DeepMath-103K), combining the two async mechanisms already in the cookbook:

- **Bounded off-policy training** (as in `rl/train_grpo_async.py`): rollout workers generate solutions continuously against the Loops sampler while the trainer takes optimizer steps concurrently. Staleness is capped by `max_steps_off_policy` — trajectory groups sampled more than that many steps behind the current policy are requeued instead of trained on.
- **Warm-start sampler provisioning** (as in `multiturn_rl/train_twenty_questions_async.py`): `LOOPS_WARM_START_SAMPLER=true` provisions the paired sampler in parallel with the trainer, so the two cold starts overlap.

DeepMath solutions are long chains of reasoning with widely varying length across a batch — the regime where async mode pays off, since a synchronous loop would idle the trainer for the slowest solution in every batch.

Also updates the Loops README (recipe table, run commands, async RL section) to cover the new recipe.

## Verification: measured speedup on Qwen/Qwen3-0.6B

Ran this recipe against a synchronous baseline with an identical config (`Qwen/Qwen3-0.6B`, DeepMath, 16 groups × 8 samples, `max_tokens=1024`, 8 optimizer steps):

| | Sync baseline | Async (this recipe) |
| --- | --- | --- |
| End-to-end wall clock (incl. provisioning) | 1201s | 488s (**2.46×**) |
| Steady-state per optimizer step | 25.2s (13.4s sampling + 11.8s train/publish, sequential) | 11.0s (**2.29×**) |
| Sampler cold start | serialized after trainer (369s + ~337s before first trajectory) | overlapped with trainer via warm start (log: "Creating the paired Loops sampler … so it boots alongside the trainer") |

- Async steady-state step time (~11s) matches the train/publish floor — sampling is fully hidden behind optimizer steps.
- Off-policy bound held exactly: from step 5 on, the trainer trains on trajectories sampled 2 policy versions back (`training_client/step` − `sampling_client/step` = 2 = `max_steps_off_policy`), never more.
- Cold-start caveat: the async run's trainer provisioned in 43s vs 369s for sync (warm infra from the earlier run), so the end-to-end 2.46× partly reflects that; the steady-state 2.29× is apples-to-apples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FApFApoDUV4e9YABFyfZP4