### PR TITLE
Bump baseten-loops to 0.18.0, drop stale LOOPS_PROJECT_ID docs

### DIFF
--- a/recipes/loops/README.md
+++ b/recipes/loops/README.md
@@ -18,11 +18,10 @@ These recipes use [tinker-cookbook](https://pypi.org/project/tinker-cookbook/)'s
 
 ## Setup
 
-You need [uv](https://docs.astral.sh/uv/), a [Baseten account](https://app.baseten.co/signup), and a training project. Then:
+You need [uv](https://docs.astral.sh/uv/) and a [Baseten account](https://app.baseten.co/signup). Then:
 
 ```bash
 export BASETEN_API_KEY="your-api-key"
-export LOOPS_PROJECT_ID="proj_abc123"
 uv sync
 ```
 

--- a/recipes/loops/multiturn_rl/train_twenty_questions.py
+++ b/recipes/loops/multiturn_rl/train_twenty_questions.py
@@ -9,7 +9,7 @@ sampler) responds, until the player guesses the secret word or runs out of
 turns. The environment lives in env.py and is the part you'd adapt to build
 your own multi-turn task.
 
-Set BASETEN_API_KEY and LOOPS_PROJECT_ID before running:
+Set BASETEN_API_KEY before running:
 
     uv run multiturn_rl/train_twenty_questions.py
 

--- a/recipes/loops/multiturn_rl/train_twenty_questions_async.py
+++ b/recipes/loops/multiturn_rl/train_twenty_questions_async.py
@@ -18,7 +18,7 @@ that staleness: every trajectory group is tagged with the policy version it
 was sampled from, and groups more than `max_steps_off_policy` optimizer steps
 behind the current trainer step are requeued instead of trained on.
 
-Set BASETEN_API_KEY and LOOPS_PROJECT_ID before running:
+Set BASETEN_API_KEY before running:
 
     uv run multiturn_rl/train_twenty_questions_async.py
 

--- a/recipes/loops/pyproject.toml
+++ b/recipes/loops/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "baseten-loops-tinker>=0.12.0",
     "chz",
     "wandb>=0.16.0",
-    "baseten-loops>=0.16.0",
+    "baseten-loops>=0.18.0",
 ]
 
 [tool.uv]

--- a/recipes/loops/rl/train_grpo.py
+++ b/recipes/loops/rl/train_grpo.py
@@ -4,8 +4,7 @@
 """GRPO on GSM8K math problems.
 
 Uses tinker-cookbook's RL training loop, running against a Baseten Loops
-trainer/sampler pair via the baseten-loops-tinker shim. Set BASETEN_API_KEY
-and LOOPS_PROJECT_ID before running:
+trainer/sampler pair via the baseten-loops-tinker shim. Set BASETEN_API_KEY before running:
 
     uv run rl/train_grpo.py
 

--- a/recipes/loops/rl/train_grpo_async.py
+++ b/recipes/loops/rl/train_grpo_async.py
@@ -19,7 +19,7 @@ published to the paired sampler after every step, and sampling requests carry
 an `X-Min-Policy-Version` floor so a rollout is never served by weights older
 than the version it was pinned to.
 
-Set BASETEN_API_KEY and LOOPS_PROJECT_ID before running:
+Set BASETEN_API_KEY before running:
 
     uv run rl/train_grpo_async.py
 

--- a/recipes/loops/sft/train_sft.py
+++ b/recipes/loops/sft/train_sft.py
@@ -4,8 +4,7 @@
 """Supervised fine-tuning on the HuggingFaceH4/no_robots chat dataset.
 
 Uses tinker-cookbook's supervised training loop, running against a Baseten
-Loops trainer via the baseten-loops-tinker shim. Set BASETEN_API_KEY and
-LOOPS_PROJECT_ID before running:
+Loops trainer via the baseten-loops-tinker shim. Set BASETEN_API_KEY before running:
 
     uv run sft/train_sft.py
 

--- a/recipes/loops/sft/train_sft_glm.py
+++ b/recipes/loops/sft/train_sft_glm.py
@@ -23,8 +23,7 @@ Two GLM-specific wrinkles this file handles:
    `tokenizer.apply_chat_template` before any GPU time is spent, so template
    drift fails fast.
 
-Trains on the HuggingFaceH4/no_robots chat dataset. Set BASETEN_API_KEY and
-LOOPS_PROJECT_ID before running:
+Trains on the HuggingFaceH4/no_robots chat dataset. Set BASETEN_API_KEY before running:
 
     uv run sft/train_sft_glm.py
 

--- a/recipes/loops/uv.lock
+++ b/recipes/loops/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "baseten-loops"
-version = "0.16.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datasets" },
@@ -188,9 +188,9 @@ dependencies = [
     { name = "truss" },
     { name = "wandb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/ad/e03c38b8bd5fd38169748530ffc85011bf6cf4a0015b0498cccb157ebd33/baseten_loops-0.16.0.tar.gz", hash = "sha256:e7e11005d5386ce9af8af983dd7519c7af65f4daff336d23c5805e7b0f4917a7", size = 288520, upload-time = "2026-08-04T17:09:41.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/e6/5c224a646156454579f9faa9d70ad1db3e9712fcc2d3f05357b8ae872ebc/baseten_loops-0.18.0.tar.gz", hash = "sha256:c02b4ad7f668c993e6bf200b0a2dcd69b60c711c412e676f096fac11554bc464", size = 290976, upload-time = "2026-08-20T21:21:49.585Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/4b/04b574e118b0a58f127693a39db53f347641237e38dbfb1bf4061d7dfaa9/baseten_loops-0.16.0-py3-none-any.whl", hash = "sha256:94a1f88518f9669f1f663e0d5a880090a789eb1a489ccb5383fd1e2e70dd860b", size = 69220, upload-time = "2026-08-04T17:09:39.437Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/2b5390940ab4f86c74049f32ff6a9cd92aff92f1d2520ad6ee8bcd79e53a/baseten_loops-0.18.0-py3-none-any.whl", hash = "sha256:20f1c6d6f894528c0b1578190afeb1196bfcd144a96675129ff4e38a7149654d", size = 70304, upload-time = "2026-08-20T21:21:47.972Z" },
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "baseten-loops", specifier = ">=0.16.0" },
+    { name = "baseten-loops", specifier = ">=0.18.0" },
     { name = "baseten-loops-tinker", specifier = ">=0.12.0" },
     { name = "chz" },
     { name = "tinker-cookbook", extras = ["math-rl"] },


### PR DESCRIPTION
## What

- Bumps the Loops recipes' `baseten-loops` floor from `>=0.16.0` to `>=0.18.0` and refreshes `uv.lock` accordingly.
- Removes `LOOPS_PROJECT_ID` from the recipe docstrings and README setup.

## Why

**SDK bump**: the locked 0.16.0 has a `/sample` ReadError retry livelock: under the RL recipes' concurrent sampling, every request fails on read and retries indefinitely, so step 0 never completes (observed: 3,000+ retries over 7 hours on the twenty-questions recipe, zero steps). The identical run on the same machine with 0.18.0 completed 5 steps in 2 hours with 19 benign retries. Raising the floor (not just the lock) also fixes copies of the recipe made without the lockfile. Verified end to end by running the twenty-questions recipe to completion of multiple RL steps.

**LOOPS_PROJECT_ID removal**: nothing reads this env var. It appears in no code path in `baseten-loops` or `baseten-loops-tinker` (the tinker shim's `project_id` kwarg is explicitly discarded with an "unsupported" warning), and a default training project is assigned automatically when none is given. The instruction sends users hunting for a value that does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)